### PR TITLE
Fix for off-by-one panning issues 

### DIFF
--- a/dygraph.js
+++ b/dygraph.js
@@ -837,7 +837,6 @@ Dygraph.movePan = function(event, g, context) {
   // y-axis scaling is automatic unless this is a full 2D pan.
   if (context.is2DPan) {
     // Adjust each axis appropriately.
-    var y_frac = context.dragEndY / g.height_;
     for (var i = 0; i < g.axes_.length; i++) {
       var axis = g.axes_[i];
       var maxValue = axis.initialTopValue +


### PR DESCRIPTION
This fix removes the original notion of remembering what values the cursor spot referred to, and instead uses something simpler (and IMO) an easier conceptual model. (You can tell by the absence of y_frac).

This conceptual model doesn't work with log scaling, and panning via log scale is another matter altogether. But I have an idea about that. One thing at a time. :)
