### PR TITLE
Bugfix for hovering on last point

### DIFF
--- a/dygraph.js
+++ b/dygraph.js
@@ -1411,10 +1411,6 @@ Dygraph.prototype.mouseMove_ = function(event) {
     idx = i;
   }
   if (idx >= 0) lastx = points[idx].xval;
-  // Check that you can really highlight the last day's data
-  var last = points[points.length-1];
-  if (last != null && canvasx > last.canvasx)
-    lastx = points[points.length-1].xval;
 
   // Extract the points we've selected
   this.selPoints_ = [];

--- a/tests/connect-separated.html
+++ b/tests/connect-separated.html
@@ -23,8 +23,8 @@
         [ new Date("2009/12/03"), null, null, 12],
         [ new Date("2009/12/04"), 20, 14, null],
         [ new Date("2009/12/05"), 15, null, 17],
-        [ new Date("2009/12/06"), 18, null, 16],
-        [ new Date("2009/12/07"), 12, 14, 19]
+        [ new Date("2009/12/06"), 18, null, null],
+        [ new Date("2009/12/07"), 12, 14, null]
       ],
       {
         connectSeparatedPoints: true,


### PR DESCRIPTION
Hey Dan, we discovered a bug where if the final points of a data series are null, you couldn't hover over points from other series that were beyond that.  I fixed it by removing a block of code that's existed since the first github checkin.  I'm fairly certain that block of code isn't necessary anymore, it doesn't seem to do anything, but you might know something I don't.
