### PR TITLE
The first run of the performance web page will skew the results of future runs because the parameters are different.

### DIFF
--- a/tests/dygraph-many-points-benchmark.html
+++ b/tests/dygraph-many-points-benchmark.html
@@ -103,7 +103,6 @@
       document.getElementById('num_series_input').value = '1';
       document.getElementById('roll_period_input').value = '1';
       document.getElementById('repetitions').value = '1';
-      updatePlot();
     </script>
   </body>
 </html>


### PR DESCRIPTION
the first run will skew the results.
