### PR TITLE
Speed up the iterations of renderLineCharts

### DIFF
--- a/dygraph-layout.js
+++ b/dygraph-layout.js
@@ -129,6 +129,11 @@ DygraphLayout.prototype._evaluateLimits = function() {
 DygraphLayout.prototype._evaluateLineCharts = function() {
   // add all the rects
   this.points = new Array();
+  // An array to keep track of how many points will be drawn for each set.
+  // This will allow for the canvas renderer to not have to check every point
+  // for every data set since the points are added in order of the sets in datasets
+  this.setPointsLengths = new Array();
+
   for (var setName in this.datasets) {
     if (!this.datasets.hasOwnProperty(setName)) continue;
 
@@ -141,6 +146,7 @@ DygraphLayout.prototype._evaluateLineCharts = function() {
     var prevYPx = NaN;
     var currXPx = NaN;
     var currYPx = NaN;
+    var setPointsLength = 0;
 
     // Ignore the pixel skipping optimization if there are error bars.
     var skip_opt = (this.attr_("errorBars") ||
@@ -178,10 +184,12 @@ DygraphLayout.prototype._evaluateLineCharts = function() {
           name: setName
         };
         this.points.push(point);
+	setPointsLength += 1;
       }
       prevXPx = currXPx;
       prevYPx = currYPx;
     }
+    this.setPointsLengths.push(setPointsLength);
   }
 };
 


### PR DESCRIPTION
changed renderLineCharts algorithm for graphs without errorbars  from O(k^2 \* n) to O(k \* n) where k is number of series and n is number of points per series.  The overall speed up varies greatly, but is always positive.  The following test case has a speed up of about 50%.

Random Points
Number of points: 1000
Number of series: 100
Roll period (in points): 1
Repetitions: 10

before:
Durations: 595,553,566,575,673,567,687,564,562,767 Average: 610.9

after:
Durations: 417,412,370,444,371,490,385,380,538,386 Average: 419.3
