### PR TITLE
Test case for x axis label formatting.

### DIFF
--- a/auto_tests/tests/axis_labels.js
+++ b/auto_tests/tests/axis_labels.js
@@ -21,6 +21,15 @@ function getYLabels() {
   return ary;
 }
 
+function getXLabels() {
+  var x_labels = document.getElementsByClassName("dygraph-axis-label-x");
+  var ary = [];
+  for (var i = 0; i < x_labels.length; i++) {
+    ary.push(x_labels[i].innerHTML);
+  }
+  return ary;
+}
+
 AxisLabelsTestCase.prototype.testMinusOneToOne = function() {
   var opts = {
     width: 480,
@@ -109,3 +118,39 @@ AxisLabelsTestCase.prototype.testSmallRangeAwayFromZero = function() {
   // TODO(danvk): this is even worse!
   assertEquals(["10","10","10","10","10","10","10","10","10","10"], getYLabels());
 };
+
+AxisLabelsTestCase.prototype.testXAxisTimeLabelFormatter = function() {  
+    var opts = {
+        width: 480,
+        height: 320
+    };
+    var data = [[5.0,0],[5.1,1],[5.2,2],[5.3,3],[5.4,4],[5.5,5],[5.6,6],[5.7,7],[5.8,8],[5.9,9]];
+    var graph = document.getElementById("graph");
+    var g = new Dygraph(graph, data, opts);
+    g.updateOptions({
+        xAxisLabelFormatter: function (totalMinutes) {            
+            var hours   = Math.floor( totalMinutes / 60);
+            var minutes = Math.floor((totalMinutes - (hours * 60)));
+            var seconds = Math.round((totalMinutes * 60) - (hours * 3600) - (minutes * 60));
+
+            if (hours   < 10) {
+                hours   = "0"+hours;
+            }
+            if (minutes < 10) {
+                minutes = "0"+minutes;
+            }
+            if (seconds < 10) {
+                seconds = "0"+seconds;
+            }
+                
+            var time = hours+':'+minutes+':'+seconds;                
+            return time;
+        }
+    });
+
+    assertEquals(["00:05:00", "00:05:06", "00:05:12", "00:05:18", "00:05:24", "00:05:30", "00:05:36", "00:05:42", "00:05:48", "00:05:54"], getXLabels());
+	// assertEquals(['5','5.1','5.2','5.3','5.4','5.5', '5.6', '5.7', '5.8', '5.9'], getXLabels());
+  
+};
+
+


### PR DESCRIPTION
Here is the test case for formatting numbers along the x-axis into time format. This is needed in order to turn "126.5" minutes into "02:06:30", e.g... I'm fairly new to js & git both, hopefully this is in proper order. 
