### PR TITLE
Safe single point per pixel

### DIFF
--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -790,7 +790,7 @@ DygraphCanvasRenderer.prototype._renderLineChart = function() {
           prevX = point.canvasx;
           prevY = point.canvasy;
         } else {
-          // Skip over points will be drawn in the same pixel.
+          // Skip over points that will be drawn in the same pixel.
           if (Math.round(prevX) == Math.round(point.canvasx) &&
               Math.round(prevY) == Math.round(point.canvasy)) {
             continue;

--- a/dygraph-layout.js
+++ b/dygraph-layout.js
@@ -141,20 +141,7 @@ DygraphLayout.prototype._evaluateLineCharts = function() {
     var dataset = this.datasets[setName];
     var axis = this.dygraph_.axisPropertiesForSeries(setName);
 
-    var graphWidth = this.dygraph_.width_;
-    var graphHeight = this.dygraph_.height_;
-    var prevXPx = NaN;
-    var prevYPx = NaN;
-    var currXPx = NaN;
-    var currYPx = NaN;
     var setPointsLength = 0;
-
-    // Ignore the pixel skipping optimization if there are error bars.
-    // XXX 2011-07-25 temporarily disabled (see autotests/tests/selection.js)
-    var skip_opt = (true ||
-                    this.attr_("errorBars") ||
-                    this.attr_("customBars") ||
-                    this.annotations.length > 0);
 
     for (var j = 0; j < dataset.length; j++) {
       var item = dataset[j];
@@ -170,27 +157,16 @@ DygraphLayout.prototype._evaluateLineCharts = function() {
       } else {
         yNormal = 1.0 - ((yValue - axis.minyval) * axis.yscale);
       }
-
-      // Current pixel coordinates that the data point would fill.
-      currXPx = Math.round(xNormal * graphWidth);
-      currYPx = Math.round(yNormal * graphHeight);
-
-      // Skip over pushing points that lie on the same pixel.
-      // TODO(antrob): optimize this for graphs with error bars.
-      if (skip_opt || prevXPx != currXPx || prevYPx != currYPx) {
-        var point = {
-          // TODO(danvk): here
-          x: xNormal,
-          y: yNormal,
-          xval: xValue,
-          yval: yValue,
-          name: setName
-        };
-        this.points.push(point);
-        setPointsLength += 1;
-      }
-      prevXPx = currXPx;
-      prevYPx = currYPx;
+      var point = {
+        // TODO(danvk): here
+        x: xNormal,
+        y: yNormal,
+        xval: xValue,
+        yval: yValue,
+        name: setName
+      };
+      this.points.push(point);
+      setPointsLength += 1;
     }
     this.setPointsLengths.push(setPointsLength);
   }


### PR DESCRIPTION
The optimization here is done strictly in DygraphCanvasRenderer.prototype._renderLineChart.  It does not remove any points, but skips over the ones that will be drawn in the same pixel.  Speed up varies, but it is roughly twice as fast for large datasets (10000 points, 10 series)
