### PR TITLE
Fix for zooming bug with connect-separated turned on.

### DIFF
--- a/dygraph.js
+++ b/dygraph.js
@@ -494,17 +494,7 @@ Dygraph.prototype.rollPeriod = function() {
  * If the Dygraph has dates on the x-axis, these will be millis since epoch.
  */
 Dygraph.prototype.xAxisRange = function() {
-  return this.dateWindow_ ? this.dateWindow_ : this.xAxisExtremes();
-};
-
-/**
- * Returns the lower- and upper-bound x-axis values of the
- * data set.
- */
-Dygraph.prototype.xAxisExtremes = function() {
-  var left = this.rawData_[0][0];
-  var right = this.rawData_[this.rawData_.length - 1][0];
-  return [left, right];
+  return [this.layout_.minxval, this.layout_.maxxval];
 };
 
 /**

--- a/tests/connect-separated.html
+++ b/tests/connect-separated.html
@@ -18,6 +18,9 @@
       connected with lines, and hovering over them should produce dot and legend
       overlays in the proper color.</p>
 
+    <p>When zoomed out, the bounds of the graph should be at 2009/12/01 and
+    2009/12/07; the all-null row with date 2009/12/11 should be ignored.</p>
+
     <div id="graphdiv" style="width:600px; height:300px;"></div>
     <script type="text/javascript">
       new Dygraph(document.getElementById("graphdiv"),
@@ -28,7 +31,8 @@
         [ new Date("2009/12/04"), 20, 14, null],
         [ new Date("2009/12/05"), 15, null, 17],
         [ new Date("2009/12/06"), 18, null, null],
-        [ new Date("2009/12/07"), 12, 14, null]
+        [ new Date("2009/12/07"), 12, 14, null],
+        [ new Date("2009/12/11"), null, null, null ]
       ],
       {
         connectSeparatedPoints: true,


### PR DESCRIPTION
Hi danvk,

When viewing a chart with connect-separated turned on, if you have data where one of the x-axis extreme points has all null values except for the timestamp, it breaks zooming in the x direction. What happens is this:
- When Dygraph.drawGraph_() is called, all of the null points are filtered out, so the graph is drawn with the extreme timestamp not shown on the graph. This is expected.
- During a zoom, xAxisRange() is called to find the extreme timestamps in order to translate a DOM coordinate to a data coordinate. Previously, xAxisRange() called xAxisExtremes() which looked directly at the raw data, so the extreme point that had been filtered out previously was returned. This caused the DOM -> Coordinate translation to be incorrect resulting in broken zooming.

My fix just has xAxisRange() return the minxval and maxxval fields of the Layout object, which seems to do all the needed calculations already.

I've also updated the connect-separated test so that the bug is apparent in the old code.
