### PR TITLE
Fix bug where second axis would extend beyond graph boundaries

### DIFF
--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -44,7 +44,7 @@ DygraphCanvasRenderer = function(dygraph, element, elementContext, layout) {
   this.annotations = new Array();
   this.chartLabels = {};
 
-  this.area = layout.plotArea;
+  this.area = layout.getPlotArea();
   this.container.style.position = "relative";
   this.container.style.width = this.width + "px";
 

--- a/dygraph-layout.js
+++ b/dygraph-layout.js
@@ -30,7 +30,6 @@ DygraphLayout = function(dygraph) {
   this.datasets = new Array();
   this.annotations = new Array();
   this.yAxes_ = null;
-  this.plotArea = this.computePlotArea_();
 
   // TODO(danvk): it's odd that xTicks_ and yTicks_ are inputs, but xticks and
   // yticks are outputs. Clean this up.
@@ -45,6 +44,10 @@ DygraphLayout.prototype.attr_ = function(name) {
 DygraphLayout.prototype.addDataset = function(setname, set_xy) {
   this.datasets[setname] = set_xy;
 };
+
+DygraphLayout.prototype.getPlotArea = function() {
+  return this.computePlotArea_();
+}
 
 // Compute the box which the chart should be drawn in. This is the canvas's
 // box, less space needed for axis and chart labels.

--- a/dygraph-range-selector.js
+++ b/dygraph-range-selector.js
@@ -77,7 +77,7 @@ DygraphRangeSelector.prototype.resize_ = function() {
     canvas.style.height = canvas.height + 'px';  // for IE
   };
 
-  var plotArea = this.layout_.plotArea;
+  var plotArea = this.layout_.getPlotArea();
   var xAxisLabelHeight = this.attr_('axisLabelFontSize') + 2 * this.attr_('axisTickSize');
   this.canvasRect_ = {
     x: plotArea.x,

--- a/tests/two-axes.html
+++ b/tests/two-axes.html
@@ -16,9 +16,9 @@
   <body>
     <h2>Multiple y-axes</h2>
     <p>The same data with both one and two y-axes. Two y-axes:</p>
-    <div id="demodiv"></div>
+    <div id="demodiv" style="width: 640; height: 350; border: 1px solid black"></div>
     <p>A single y-axis:</p>
-    <div id="demodiv_one"></div>
+    <div id="demodiv_one" style="width: 640; height: 350; border: 1px solid black"></div>
 
     <script type="text/javascript">
       var data = [];
@@ -41,8 +41,6 @@
           data,
           {
             labels: [ 'Date', 'Y1', 'Y2', 'Y3', 'Y4' ],
-            width: 640,
-            height: 350,
             'Y3': {
               axis: {
               }
@@ -64,8 +62,6 @@
           data,
           {
             labels: [ 'Date', 'Y1', 'Y2', 'Y3', 'Y4' ],
-            width: 640,
-            height: 350,
             labelsKMB: true
           }
       );


### PR DESCRIPTION
The DygraphLayout needs to recalculate its information, since the options may have changed since its construction.  In particular, it's initially constructed before axis options are parsed, causing it to always set its layout based on the assumption that there's only one axis.
