### PR TITLE
Fixing bug 87

### DIFF
--- a/auto_tests/tests/update_options.js
+++ b/auto_tests/tests/update_options.js
@@ -19,7 +19,7 @@ UpdateOptionsTestCase.prototype.data = "X,Y1,Y2\n" +
   "2011-05-05,8,3\n";
 
 UpdateOptionsTestCase.prototype.setUp = function() {
-  document.body.innerHTML = "<div id='graph'></div>";
+  document.body.innerHTML = "<div id='graph'></div><div id='labels'>";
 };
 
 UpdateOptionsTestCase.prototype.tearDown = function() {
@@ -110,3 +110,12 @@ UpdateOptionsTestCase.prototype.testWidthChangeNeedsNewPoints = function() {
   this.unWrap(oldDrawGraph);
   assertTrue(graph._testDrawCalled);
 };
+
+// Test https://github.com/danvk/dygraphs/issues/87
+UpdateOptionsTestCase.prototype.testUpdateLabelsDivDoesntInfiniteLoop = function() {
+  var graphDiv = document.getElementById("graph");
+  var labelsDiv = document.getElementById("labels");
+  var graph = new Dygraph(graphDiv, this.data, this.opts);
+  graph.updateOptions({labelsDiv : labelsDiv});
+}
+

--- a/dygraph-utils.js
+++ b/dygraph-utils.js
@@ -501,6 +501,9 @@ Dygraph.updateDeep = function (self, o) {
           self[k] = null;
         } else if (Dygraph.isArrayLike(o[k])) {
           self[k] = o[k].slice();
+        } else if (o[k] instanceof Node) {
+          // DOM objects are shallowly-copied.
+          self[k] = o[k];
         } else if (typeof(o[k]) == 'object') {
           if (typeof(self[k]) != 'object') {
             self[k] = {};


### PR DESCRIPTION
Fix infinite loop when updateOptions contains labelsDiv (or any other document node for that matter.)
