### PR TITLE
Allows unescaped HTML in X and Y labels and values.

### DIFF
--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -311,7 +311,7 @@ DygraphCanvasRenderer.prototype._renderAxis = function() {
     inner_div.className = 'dygraph-axis-label' +
                           ' dygraph-axis-label-' + axis +
                           (prec_axis ? ' dygraph-axis-label-' + prec_axis : '');
-    inner_div.appendChild(document.createTextNode(txt));
+    inner_div.innerHTML=txt;
     div.appendChild(inner_div);
     return div;
   };


### PR DESCRIPTION
For example: <b>val1</b> would be shown in bold instead of being displayed as &lt;b&gt;val1&lt;/b&gt;
