### PR TITLE
Fix stuck fading animation for series highlighting

### DIFF
--- a/dygraph.js
+++ b/dygraph.js
@@ -1851,10 +1851,8 @@ Dygraph.prototype.setLegendHTML_ = function(x, sel_points) {
 Dygraph.prototype.animateSelection_ = function(direction) {
   var totalSteps = 10;
   var millis = 30;
-  if (this.fadeLevel === undefined) {
-    this.fadeLevel = 0;
-    this.animateId = 0;
-  }
+  if (this.fadeLevel === undefined) this.fadeLevel = 0;
+  if (this.animateId === undefined) this.animateId = 0;
   var start = this.fadeLevel;
   var steps = direction < 0 ? start : totalSteps - start;
   if (steps <= 0) {


### PR DESCRIPTION
The animateId field wasn't being initialized correctly if clearSelection() got called before the first call to setSelection(), resulting in highlighting being permanently unavailable for that graph.

TODO(klausw): add more generic support for animating changes to option values?
