### PR TITLE
Fix highlighting for zoomed graphs

### DIFF
--- a/auto_tests/tests/callback.js
+++ b/auto_tests/tests/callback.js
@@ -308,3 +308,54 @@ CallbackTestCase.prototype.testNaNData = function() {
   assertEquals(1, res.row);
   assertEquals('c', res.seriesName);
 };
+
+CallbackTestCase.prototype.testGapHighlight = function() {
+var dataGap = [
+    [1, null, 3],
+    [2, 2, null],
+    [3, null, 5],
+    [4, 4, null],
+    [5, null, 7],
+    [6, NaN, null],
+    [8, 8, null],
+    [10, 10, null]];
+
+  var h_row;
+  var h_pts;
+
+  var highlightCallback  =  function(e, x, pts, row) {
+    h_row = row;
+    h_pts = pts;
+  };
+
+  var graph = document.getElementById("graph");
+  var g = new Dygraph(graph, dataGap, {
+     width: 400,
+     height: 300,
+     //stackedGraph: true,
+     connectSeparatedPoints: true,
+     drawPoints: true,
+     labels: ['x', 'A', 'B'],
+     highlightCallback : highlightCallback
+  });
+
+  DygraphOps.dispatchMouseMove(g, 1.1, 10);
+  //point from series B
+  assertEquals(0, h_row);
+  assertEquals(1, h_pts.length);
+  assertEquals(3, h_pts[0].yval);
+  assertEquals('B', h_pts[0].name);
+
+  DygraphOps.dispatchMouseMove(g, 6.1, 10);
+  // A is NaN at x=6
+  assertEquals(1, h_pts.length);
+  assert(isNaN(h_pts[0].yval));
+  assertEquals('A', h_pts[0].name);
+
+  DygraphOps.dispatchMouseMove(g, 8.1, 10);
+  //point from series A
+  assertEquals(6, h_row);
+  assertEquals(1, h_pts.length);
+  assertEquals(8, h_pts[0].yval);
+  assertEquals('A', h_pts[0].name);
+};

--- a/dygraph-layout.js
+++ b/dygraph-layout.js
@@ -215,6 +215,7 @@ DygraphLayout.prototype._evaluateLineCharts = function() {
   this.setPointsLengths = [];
   this.setPointsOffsets = [];
 
+  var connectSeparated = this.attr_('connectSeparatedPoints');
   for (var setIdx = 0; setIdx < this.datasets.length; ++setIdx) {
     var dataset = this.datasets[setIdx];
     var setName = this.setNames[setIdx];
@@ -241,6 +242,9 @@ DygraphLayout.prototype._evaluateLineCharts = function() {
         yval: yValue,
         name: setName
       };
+      if (connectSeparated && item[1] === null) {
+        point.yval = null;
+      }
       this.points.push(point);
       setPointsLength += 1;
     }

--- a/dygraph-utils.js
+++ b/dygraph-utils.js
@@ -334,12 +334,15 @@ Dygraph.isOK = function(x) {
 /**
  * @private
  * @param { Object } p The point to consider, valid points are {x, y} objects
+ * @param { Boolean } allowNaNY Treat point with y=NaN as valid
  * @return { Boolean } Whether the point has numeric x and y.
  */
-Dygraph.isValidPoint = function(p) {
+Dygraph.isValidPoint = function(p, allowNaNY) {
   if (!p) return false; // null or undefined object
-  if (isNaN(p.x) || p.x === null || p.x === undefined) return false;
-  if (isNaN(p.y) || p.y === null || p.y === undefined) return false;
+  if (p.yval === null) return false; // missing point
+  if (p.x === null || p.x === undefined) return false;
+  if (p.y === null || p.y === undefined) return false;
+  if (isNaN(p.x) || (!allowNaNY && isNaN(p.y))) return false;
   return true;
 };
 


### PR DESCRIPTION
The code wasn't correctly applying the left boundary offset when converting a row index in the pruned data to/from a row index for the full data set.

Add a getLeftBoundary_ helper method and replace the existing loops that attempted to find the first defined record. Not sure why it saves multiple boundaryIds anyway, the code assumes it can just use the first one.

Also fix an apparently-invalid usage in getSelection().
