### PR TITLE
Stacked step plot fix

### DIFF
--- a/tests/steps.html
+++ b/tests/steps.html
@@ -135,6 +135,24 @@
       }
     );
     </script>
+    
+    <p>8: Stacked filled step chart:</p>
+    <div id="graphdiv8"></div>
+    <script type="text/javascript">
+      g8 = new Dygraph(document.getElementById("graphdiv8"),
+                      "Date,Idle,Used\n" +
+                      "2008-05-07,70,30\n" +
+                      "2008-05-08,12,88\n" +
+                      "2008-05-09,88,12\n" +
+                      "2008-05-10,63,37\n" +
+                      "2008-05-11,35,65\n",
+                       {
+                          stepPlot: true,
+                          fillGraph: true,
+                          stackedGraph: true,
+                          includeZero: true
+                       });
+    </script>
 
   </body>
 </html>


### PR DESCRIPTION
Hello!

Here's a fix for issue 206: http://code.google.com/p/dygraphs/issues/detail?id=206

Stacked, filled step plots would fill down to wrong point, causing triangular edges with no fills on every set except for the first.

This change stores both the top and bottom Y values of the vertical line on the set below the one being drawn, so the fill can be drawn to the bottom point, resulting in a square fill.

I also switched the 'baseline' variable to be initialized as an object literal instead of an array literal. This doesn't make any functional difference, but it was being treated as an object with arbitrary properties, not an array.
- Dave
