### PR TITLE
null should be converted into {} in deepcopy

### DIFF
--- a/dygraph-utils.js
+++ b/dygraph-utils.js
@@ -598,7 +598,7 @@ Dygraph.updateDeep = function (self, o) {
           // DOM objects are shallowly-copied.
           self[k] = o[k];
         } else if (typeof(o[k]) == 'object') {
-          if (typeof(self[k]) != 'object') {
+          if (typeof(self[k]) != 'object' || self[k] === null) {
             self[k] = {};
           }
           Dygraph.updateDeep(self[k], o[k]);


### PR DESCRIPTION
When I want to turn series highlighting off and on again and set highlightSeriesOpts = null, then re-enabling it by setting a value for highlightSeriesOpts, it crashes in deepCopy because typeof(null) == "object" and thus an empty object is not created.
This small fix should take care of this problem (and possibly others with nested objects in options).
