### PR TITLE
Export .isSeriesLocked() API function

### DIFF
--- a/auto_tests/tests/callback.js
+++ b/auto_tests/tests/callback.js
@@ -304,7 +304,7 @@ CallbackTestCase.prototype.testClosestPointCallbackCss2 = function() {
 /**
  * Closest-point highlighting with locked series.
  */
-CallbackTestCase.prototype.testClosestPointCallbackCss1 = function() {
+CallbackTestCase.prototype.testSetSelectionLocking = function() {
   var g = runClosestTest(false, 2, 4);
 
   // Default behavior, 'b' is closest

--- a/dygraph.js
+++ b/dygraph.js
@@ -1734,7 +1734,7 @@ Dygraph.prototype.mouseMove_ = function(event) {
 
   var highlightSeriesOpts = this.attr_("highlightSeriesOpts");
   var selectionChanged = false;
-  if (highlightSeriesOpts && !this.lockedSet_) {
+  if (highlightSeriesOpts && !this.isSeriesLocked()) {
     var closest;
     if (this.attr_("stackedGraph")) {
       closest = this.findStackedPoint(canvasx, canvasy);
@@ -2022,6 +2022,14 @@ Dygraph.prototype.getSelection = function() {
  */
 Dygraph.prototype.getHighlightSeries = function() {
   return this.highlightSet_;
+};
+
+/**
+ * Returns true if the currently-highlighted series was locked
+ * via setSelection(..., seriesName, true).
+ */
+Dygraph.prototype.isSeriesLocked = function() {
+  return this.lockedSet_;
 };
 
 /**

--- a/gallery/highlighted-series.js
+++ b/gallery/highlighted-series.js
@@ -27,19 +27,6 @@ var getData = function(numSeries, numRows, isStacked) {
   return data;
 };
 
-var makeClickCallback = function(graph) {
-  var isLocked = false;
-  return function(ev) {
-    if (isLocked) {
-      graph.clearSelection();
-      isLocked = false;
-    } else {
-      graph.setSelection(graph.getSelection(), graph.getHighlightSeries(), true);
-      isLocked = true;
-    }
-  };
-};
-
 var makeGraph = function(className, numSeries, numRows, isStacked) {
   var demo = document.getElementById('demo');
   var div = document.createElement('div');
@@ -73,7 +60,14 @@ var makeGraph = function(className, numSeries, numRows, isStacked) {
           highlightCircleSize: 5,
         },
       });
-  g.updateOptions({clickCallback: makeClickCallback(g)}, true);
+  var onclick = function(ev) {
+    if (g.isSeriesLocked()) {
+      g.clearSelection();
+    } else {
+      g.setSelection(g.getSelection(), g.getHighlightSeries(), true);
+    }
+  };
+  g.updateOptions({clickCallback: onclick}, true);
   g.setSelection(false, 's005');
   //console.log(g);
 };


### PR DESCRIPTION
This is a followup to https://github.com/danvk/dygraphs/pull/159,
exposing the .lockedSet_ internal attribute through the API
for use in callbacks, and also with an eye for future extraction
of the mouseover logic into a plugin.

Includes a fix for the auto_test name, it was erroneously replacing
the existing testClosestPointCallbackCss1 test due to a name clash.
