### PR TITLE
Stepplot and errorbars sync fix

### DIFF
--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -618,7 +618,7 @@ DygraphCanvasRenderer._errorPlotter = function(e) {
   ctx.beginPath();
   while (iter.hasNext) {
     var point = iter.next();
-    if (!Dygraph.isOK(point.y)) {
+    if ((!stepPlot && !Dygraph.isOK(point.y)) || (stepPlot && !isNaN(prevY) && !Dygraph.isOK(prevY))) {
       prevX = NaN;
       continue;
     }
@@ -633,17 +633,15 @@ DygraphCanvasRenderer._errorPlotter = function(e) {
     newYs[1] = e.plotArea.h * newYs[1] + e.plotArea.y;
     if (!isNaN(prevX)) {
       if (stepPlot) {
-        ctx.moveTo(prevX, newYs[0]);
+        ctx.moveTo(prevX, prevYs[0]);
+        ctx.lineTo(point.canvasx, prevYs[0]);
+        ctx.lineTo(point.canvasx, prevYs[1]);
       } else {
         ctx.moveTo(prevX, prevYs[0]);
+        ctx.lineTo(point.canvasx, newYs[0]);
+        ctx.lineTo(point.canvasx, newYs[1]);
       }
-      ctx.lineTo(point.canvasx, newYs[0]);
-      ctx.lineTo(point.canvasx, newYs[1]);
-      if (stepPlot) {
-        ctx.lineTo(prevX, newYs[1]);
-      } else {
-        ctx.lineTo(prevX, prevYs[1]);
-      }
+      ctx.lineTo(prevX, prevYs[1]);
       ctx.closePath();
     }
     prevYs = newYs;


### PR DESCRIPTION
The 1st error bar wasn't drawn on stepplots, instead the script started with drawing the horizontal line of the 2nd error bar which was then shown under the 1st value, the 3rd error bar was drawn under the 2nd value, etc, what resulted in an incorrect graph.

Demo:

Without the fix:
http://wimme.net/temp/dygraphs1/index.htm
http://wimme.net/temp/dygraphs1/weather.htm
Notice how the error bars and the line charts are not in sync, the error bar is one value ahead

With the fix:
http://wimme.net/temp/dygraphs2/
http://wimme.net/temp/dygraphs2/weather.htm
Here are the error bars and the line charts nicely in sync, the way it should be.

(I've submitted this one before here https://github.com/danvk/dygraphs/pull/122 - my apologizes for replying so late)
