### PR TITLE
Fix the background color around the axis labels in IE.

### DIFF
--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -176,7 +176,7 @@ DygraphCanvasRenderer.prototype._createIEClipArea = function() {
   }
 
   // Determine background color to give clip divs.
-  var backgroundColor = document.bgColor;
+  var backgroundColor = graphDiv.style.bgColor;
   var element = this.dygraph_.graphDiv;
   while (element != document) {
     var bgcolor = element.currentStyle.backgroundColor;


### PR DESCRIPTION
In IE set background color of the clip div to the same as the graph div,
making it consistent with other browsers.
