### PR TITLE
synching dygraph-dev and generate-combined

### DIFF
--- a/generate-combined.sh
+++ b/generate-combined.sh
@@ -6,6 +6,11 @@
 # This list needs to be kept in sync w/ the one in dygraph-dev.js
 # and the one in jsTestDriver.conf.
 cat \
+strftime/strftime-min.js \
+rgbcolor/rgbcolor.js \
+stacktrace.js \
+dashed-canvas.js \
+dygraph-options.js \
 dygraph-layout.js \
 dygraph-canvas.js \
 dygraph.js \
@@ -14,9 +19,6 @@ dygraph-gviz.js \
 dygraph-interaction-model.js \
 dygraph-range-selector.js \
 dygraph-tickers.js \
-rgbcolor/rgbcolor.js \
-strftime/strftime-min.js \
-dashed-canvas.js \
 plugins/base.js \
 plugins/annotations.js \
 plugins/axes.js \


### PR DESCRIPTION
generate-combined was pulling in files in a different order than dev, and completely missing dygraph-options.js file.
