### PR TITLE
refactor generate-combined.sh

### DIFF
--- a/closure-todo.txt
+++ b/closure-todo.txt
@@ -20,14 +20,14 @@ x dygraph-tickers.js
 x dygraph-options-reference.js
 x dygraph-utils.js
 x dashed-canvas.js
+- dygraph-plugin-base.js
+- dygraph-plugin-install.js
 
 Plugins:
 - plugins/annotations.js
 - plugins/axes.js
-- plugins/base.js
 - plugins/chart-labels.js
 - plugins/grid.js
-- plugins/install.js
 - plugins/legend.js
 
 Here's a command that can be used to build dygraphs using the closure

--- a/dygraph-dev.js
+++ b/dygraph-dev.js
@@ -28,14 +28,14 @@
     "dygraph-gviz.js",
     "dygraph-interaction-model.js",
     "dygraph-tickers.js",
-    "plugins/base.js",
+    "dygraph-plugin-base.js",
     "plugins/annotations.js",
     "plugins/axes.js",
     "plugins/chart-labels.js",
     "plugins/grid.js",
     "plugins/legend.js",
     "plugins/range-selector.js",
-    "plugins/install.js",
+    "dygraph-plugin-install.js",
     "dygraph-options-reference.js"  // Shouldn't be included in generate-combined.sh
   ];
 

--- a/dygraph-plugin-base.js
+++ b/dygraph-plugin-base.js
@@ -1,0 +1,4 @@
+/*global Dygraph:false */
+
+// Namespace for plugins. Load this before plugins/*.js files.
+Dygraph.Plugins = {};

--- a/dygraph-plugin-install.js
+++ b/dygraph-plugin-install.js
@@ -9,7 +9,6 @@
 // This is most relevant for plugins which register a layout event, e.g.
 // Axes, Legend and ChartLabels.
 
-// TODO(danvk): move this into the top-level directory. Only plugins here.
 Dygraph.PLUGINS.push(
   Dygraph.Plugins.Legend,
   Dygraph.Plugins.Axes,

--- a/file-size-stats.sh
+++ b/file-size-stats.sh
@@ -15,14 +15,14 @@ dygraph-tickers.js \
 rgbcolor/rgbcolor.js \
 strftime/strftime-min.js \
 dashed-canvas.js \
-plugins/base.js \
+dygraph-plugin-base.js \
 plugins/annotations.js \
 plugins/axes.js \
 plugins/range-selector.js \
 plugins/chart-labels.js \
 plugins/grid.js \
 plugins/legend.js \
-plugins/install.js \
+dygraph-plugin-install.js \
 ; do
   base_size=$(cat $file | wc -c)
   cat $file \

--- a/generate-combined.sh
+++ b/generate-combined.sh
@@ -1,39 +1,65 @@
 #!/bin/bash
 # Generates a single JS file that's easier to include.
 
+GetSources () {
+  # This list needs to be kept in sync w/ the one in dygraph-dev.js
+  # and the one in jsTestDriver.conf. Order matters, except for the plugins.
+  for F in \
+    strftime/strftime-min.js \
+    rgbcolor/rgbcolor.js \
+    stacktrace.js \
+    dashed-canvas.js \
+    dygraph-options.js \
+    dygraph-layout.js \
+    dygraph-canvas.js \
+    dygraph.js \
+    dygraph-utils.js \
+    dygraph-gviz.js \
+    dygraph-interaction-model.js \
+    dygraph-tickers.js \
+    dygraph-plugin-base.js \
+    plugins/*.js \
+    dygraph-plugin-install.js
+  do
+      echo "$F"
+  done
+}
+
 # Pack all the JS together.
+CatSources () {
+  GetSources \
+  | xargs cat \
+  | perl -ne 'print unless m,REMOVE_FOR_COMBINED,..m,/REMOVE_FOR_COMBINED,'
+}
 
-# This list needs to be kept in sync w/ the one in dygraph-dev.js
-# and the one in jsTestDriver.conf.
-cat \
-strftime/strftime-min.js \
-rgbcolor/rgbcolor.js \
-stacktrace.js \
-dashed-canvas.js \
-dygraph-options.js \
-dygraph-layout.js \
-dygraph-canvas.js \
-dygraph.js \
-dygraph-utils.js \
-dygraph-gviz.js \
-dygraph-interaction-model.js \
-dygraph-tickers.js \
-plugins/base.js \
-plugins/annotations.js \
-plugins/axes.js \
-plugins/chart-labels.js \
-plugins/grid.js \
-plugins/legend.js \
-plugins/range-selector.js \
-plugins/install.js \
-| perl -ne 'print unless m,REMOVE_FOR_COMBINED,..m,/REMOVE_FOR_COMBINED,' \
-> /tmp/dygraph.js
-
-java -jar yuicompressor-2.4.2.jar /tmp/dygraph.js \
-> /tmp/dygraph-packed.js
-
-(
+Copyright () {
   echo '/*! @license Copyright 2011 Dan Vanderkam (danvdk@gmail.com) MIT-licensed (http://opensource.org/licenses/MIT) */'
-  cat /tmp/dygraph-packed.js
-) > dygraph-combined.js
-chmod a+r dygraph-combined.js
+}
+
+CatCompressed () {
+  Copyright
+  CatSources \
+  | java -jar yuicompressor-2.4.2.jar --type js
+}
+
+ACTION="${1:-update}"
+case "$ACTION" in
+ls)
+  GetSources
+  ;;
+cat)
+  Copyright
+  CatSources
+  ;;
+compress*|cat_compress*)
+  CatCompressed
+  ;;
+update)
+  CatCompressed > dygraph-combined.js
+  chmod a+r dygraph-combined.js
+  ;;
+*)
+  echo >&2 "Unknown action '$ACTION'"
+  exit 1
+  ;;
+esac

--- a/jsTestDriver.conf
+++ b/jsTestDriver.conf
@@ -17,13 +17,7 @@ load:
   - dygraph-tickers.js
   - dygraph-dev.js
   - excanvas.js
-  # NOTE: we can't do plugins/*.js because the order is important.
-  - plugins/base.js
-  - plugins/annotations.js
-  - plugins/axes.js
-  - plugins/range-selector.js
-  - plugins/chart-labels.js
-  - plugins/grid.js
-  - plugins/legend.js
-  - plugins/install.js
+  - dygraph-plugin-base.js
+  - plugins/*.js
+  - dygraph-plugin-install.js
   - auto_tests/tests/*.js

--- a/plugins/base.js
+++ b/plugins/base.js
@@ -1,6 +1,0 @@
-/*global Dygraph:false */
-
-// Namespace for plugins.
-Dygraph.Plugins = {};
-
-// TODO(danvk): move this into the top-level directory. Only plugins here.


### PR DESCRIPTION
Update the generate-combined.sh script to support printing an ordered
source file list, cat'ing the compressed or uncompressed output, or
updating the dygraph-combined.js file (the default). This is intended to
make it easier to integrate dygraphs code into other builds.

Move the plugins/{base,install}.js files to
dygraph-plugin-{base,install}.js, this simplifies the file list
by permitting use of plugins/*.js with no order dependency.
