### PR TITLE
Don't redraw graph stack in interactive highlight

### DIFF
--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -474,7 +474,7 @@ DygraphCanvasRenderer.prototype._renderLineChart = function(opt_seriesName, opt_
 
     for (var j = 0; j < sets.length; j++) {
       setName = setNames[j];
-      if (opt_seriesName && setName != opt_seriesName) continue;
+      if (opt_seriesName && !(is_last && setName == opt_seriesName)) continue;
 
       var points = sets[j];
 


### PR DESCRIPTION
When drawing a single series during interactive highlight,
only use the last plotter.

Fixes issue 424.
