### PR TITLE
Re-do the fix for stacked graph highlighting

### DIFF
--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -514,7 +514,7 @@ DygraphCanvasRenderer.prototype._renderLineChart = function(opt_seriesName, opt_
         plotArea: this.area,
         seriesIndex: j,
         seriesCount: sets.length,
-        onlySeries: opt_seriesName,
+        singleSeriesName: opt_seriesName,
         allSeriesPoints: sets
       });
       ctx.restore();
@@ -672,9 +672,11 @@ DygraphCanvasRenderer._errorPlotter = function(e) {
  * @private
  */
 DygraphCanvasRenderer._fillPlotter = function(e) {
+  // Skip if we're drawing a single series for interactive highlight overlay.
+  if (e.singleSeriesName) return;
+
   // We'll handle all the series at once, not one-by-one.
   if (e.seriesIndex !== 0) return;
-  if (e.onlySeries) return;
 
   var g = e.dygraph;
   var setNames = g.getLabels().slice(1);  // remove x-axis


### PR DESCRIPTION
This reverts the change from https://github.com/danvk/dygraphs/pull/211
and instead provides a boolean arg to the plotter so that it can decide
not to draw if needed.

The problem with the approach from #211 is that this prevents error bars
from being highlighted, and those should be redrawn on mouseover.

Fixes issue 424.
