### PR TITLE
Make dygraph-tickers more independent

### DIFF
--- a/dygraph-tickers.js
+++ b/dygraph-tickers.js
@@ -479,7 +479,13 @@ Dygraph.getDateAxis = function(start_time, end_time, granularity, opts, dg) {
   return ticks;
 };
 
-// These are set here so that this file can be included after dygraph.js.
+// These are set here so that this file can be included after dygraph.js
+// or independently.
+Dygraph.DEFAULT_ATTRS = Dygraph.DEFAULT_ATTRS || {};
+Dygraph.DEFAULT_ATTRS['axes'] = Dygraph.DEFAULT_ATTRS['axes'] || {};
+Dygraph.DEFAULT_ATTRS['axes']['x'] = Dygraph.DEFAULT_ATTRS['axes']['x'] || {};
+Dygraph.DEFAULT_ATTRS['axes']['y'] = Dygraph.DEFAULT_ATTRS['axes']['y'] || {};
+Dygraph.DEFAULT_ATTRS['axes']['y2'] = Dygraph.DEFAULT_ATTRS['axes']['y2'] || {};
 Dygraph.DEFAULT_ATTRS['axes']['x']['ticker'] = Dygraph.dateTicker;
 Dygraph.DEFAULT_ATTRS['axes']['y']['ticker'] = Dygraph.numericTicks;
 Dygraph.DEFAULT_ATTRS['axes']['y2']['ticker'] = Dygraph.numericTicks;


### PR DESCRIPTION
This will allow for dygraph-tickers.js to more easily be included without the rest of the Dygraphs source.

Note that Dygraph will still be undefined. Adding the following line adds a lint warning:

``` javascript
Dygraph = Dygraph || {};
```

```
[jshint] Error(s) in dygraph-tickers.js:
Read only. (dygraph-tickers.js:65:1)
> Dygraph = Dygraph || {};
```

Not sure what to do about this part, or if anything needs to be done.
