### PR TITLE
Y-axis labels: hidden overflow fix

### DIFF
--- a/plugins/axes.js
+++ b/plugins/axes.js
@@ -119,10 +119,11 @@ axes.prototype.willDrawChart = function(e) {
       fontSize: g.getOptionForAxis('axisLabelFontSize', axis) + "px",
       zIndex: 10,
       color: g.getOptionForAxis('axisLabelColor', axis),
-      width: g.getOption('axisLabelWidth') + "px",
+      // width: g.getOption('axisLabelWidth') + "px",
       // height: g.getOptionForAxis('axisLabelFontSize', 'x') + 2 + "px",
       lineHeight: "normal",  // Something other than "normal" line-height screws up label positioning.
-      overflow: "hidden"
+      overflow: "visible", // Always fully show label values, to avoid showing 100 while the actual value is 10000.
+      backgroundColor: g.getOptionForAxis('axisLabelBackgroundColor', axis)
     };
   };
 
@@ -203,7 +204,7 @@ axes.prototype.willDrawChart = function(e) {
                               g.getOption('axisTickSize')) + "px";
           label.style.textAlign = "left";
         }
-        label.style.width = g.getOption('yAxisLabelWidth') + "px";
+        // label.style.width = g.getOption('yAxisLabelWidth') + "px";
         containerDiv.appendChild(label);
         this.ylabels_.push(label);
       }


### PR DESCRIPTION
I know there is a (y)axisLabelWidth option, but in our application we don't know what for data the user will load into the graph, so we can't really put a fixed value on this.

Therefor it would be better if dygraph would always fully show the values in the Y-axis, no matter what the axisLabelWidth might be. Otherwise it can create situations like this:
![af00bd54-7f49-11e2-9d56-bea267e7c6ee](https://f.cloud.github.com/assets/1446260/229088/75dbbcb6-8694-11e2-97ef-07cf92093d1e.jpg)

In this graph the amount of handles of a particular process are shown, but it should be 60000 handles instead of 600. Also in our application some values (like exception values etc) have a special value and are being replaced by text, as you can see in the graph at the bottom, where it should say 'Not initialized' instead of 'Not'.

In this patch I also added a backgroundcolor option, so when the labels would overlap with the axis/graph the label would have a background, just like the mouse-over legend.
