### PR TITLE
Fix in Dygraph.log for IE8

### DIFF
--- a/dygraph-utils.js
+++ b/dygraph-utils.js
@@ -79,7 +79,7 @@ Dygraph.log = function(severity, message) {
     // In older versions of Firefox, only console.log is defined.
     var console = window.console;
     var log = function(console, method, msg) {
-      if (method) {
+      if (method && typeof(method) == 'function') {
         method.call(console, msg);
       } else {
         console.log(msg);


### PR DESCRIPTION
In IE8, the console.log functions aren't true Javascript functions. They don't support the "apply" or "call" methods.

All Javascript code stopped working when a log message was being generated, therefor this small fix.
