### PR TITLE
Bugfix: Avoid exception when returning the index of the point and one or more series are hidden

### DIFF
--- a/dygraph-layout.js
+++ b/dygraph-layout.js
@@ -211,6 +211,10 @@ DygraphLayout.prototype._evaluateLineCharts = function() {
   // on chrome+linux, they are 6 times more expensive than iterating through the
   // points and drawing the lines. The brunt of the cost comes from allocating
   // the |point| structures.
+  var boundaryIdStart = 0;
+  if (this.dygraph_.boundaryIds_.length > 0) {
+    boundaryIdStart = this.dygraph_.boundaryIds_[this.dygraph_.boundaryIds_.length-1][0]
+  }
   for (var setIdx = 0; setIdx < this.datasets.length; setIdx++) {
     var dataset = this.datasets[setIdx];
     var setName = this.setNames[setIdx];
@@ -243,7 +247,7 @@ DygraphLayout.prototype._evaluateLineCharts = function() {
         xval: xValue,
         yval: yValue,
         name: setName,  // TODO(danvk): is this really necessary?
-        idx: j + this.dygraph_.boundaryIds_[setIdx][0]
+        idx: j + boundaryIdStart
       };
     }
 


### PR DESCRIPTION
The last changes regarding the index for the datapoint caused some tests where a series is hidden to fail. This is due to the fact, that the boundaryIds array for the hidden series is skipped. 

This pull-request fixes the issue. However it might be cleaner or better to either have a boundaryIds array without gaps (fill them also if the series is hidden) or don't create the points at all.
