### PR TITLE
Document strokeWidth: 0 for scatter plots

### DIFF
--- a/dygraph-options-reference.js
+++ b/dygraph-options-reference.js
@@ -365,7 +365,7 @@ Dygraph.OPTIONS_REFERENCE =  // <JSON>
     "labels": ["Data Line display"],
     "type": "float",
     "example": "0.5, 2.0",
-    "description": "The width of the lines connecting data points. This can be used to increase the contrast or some graphs."
+    "description": "The width of the lines connecting data points. This can be used to increase the contrast of some graphs, or to disable the display of lines and get a scatter plot (strokeWidth: 0)."
   },
   "strokePattern": {
     "default": "null",


### PR DESCRIPTION
I've been looking for a way to disable lines between points (connectSeparatePoints is insufficient), in order to generate a scatter plot. Maybe it's worth creating an alias to `strokeWidth: 0` as `drawLines: false`?
