### PR TITLE
Only resize canvas if the size changed.

### DIFF
--- a/auto_tests/tests/resize.js
+++ b/auto_tests/tests/resize.js
@@ -6,13 +6,13 @@
 var ResizeTestCase = TestCase("resize");
 
 ResizeTestCase.data =
-      "Date,Y\n" +
-      "2010/01/01,100\n" +
-      "2010/02/01,200\n" +
-      "2010/03/01,300\n" +
-      "2010/04/01,400\n" +
-      "2010/05/01,300\n" +
-      "2010/06/01,100\n";
+      "X,Y\n" +
+      "1,100\n" +
+      "2,200\n" +
+      "3,300\n" +
+      "4,400\n" +
+      "5,300\n" +
+      "6,100\n";
 
 ResizeTestCase.prototype.setUp = function() {
   document.body.innerHTML = "<div id='graph'></div>";
@@ -83,11 +83,18 @@ ResizeTestCase.prototype.testHiddenDivWithResize = function() {
   div.style.width = '400px';
   div.style.height = '300px';
 
-  var g = new Dygraph(div, ResizeTestCase.data, {});
+  var g = new Dygraph(div, ResizeTestCase.data, {strokeWidth: 3});
   div.style.display = '';
 
   g.resize();
   area = g.getArea();
   assertTrue(area.w > 0);
   assertTrue(area.h > 0);
+
+  // Regression test: check that graph remains visible after no-op resize.
+  g.resize();
+  var x = Math.floor(g.toDomXCoord(2));
+  var y = Math.floor(g.toDomYCoord(200));
+  assertEquals("Unexpected grid color found at pixel: x: " + x + " y: " + y,
+               [0, 128, 128, 255], Util.samplePixel(g.hidden_, x, y));
 };

--- a/dygraph.js
+++ b/dygraph.js
@@ -3707,9 +3707,10 @@ Dygraph.prototype.resize = function(width, height) {
     this.height_ = this.maindiv_.clientHeight;
   }
 
-  this.resizeElements_();
-
   if (old_width != this.width_ || old_height != this.height_) {
+    // Resizing a canvas erases it, even when the size doesn't change, so
+    // any resize needs to be followed by a redraw.
+    this.resizeElements_();
     this.predraw_();
   }
 


### PR DESCRIPTION
Resizing the canvas erases it, and Dygraphs had skipped the redraw
when it thought it wasn't necessary, leading to blank graphs after
a redundant .resize() call.
