### PR TITLE
Fix running axis_label tests via JsTestDriver - jQuery's $ isn't defined.

### DIFF
--- a/auto_tests/tests/Util.js
+++ b/auto_tests/tests/Util.js
@@ -61,13 +61,16 @@ Util.getLegend = function(parent) {
 /**
  * Assert that all elements have a certain style property.
  */
-Util.assertStyleOfChildren = function(selector, property, expectedValue) {
-  assertTrue(selector.length > 0);
-  $.each(selector, function(idx, child) {
-    assertEquals(expectedValue,  $(child).css(property));
-  });
-};
+Util.assertStyleOfChildren = function(elements, property, expectedValue) {
 
+  assertFunction("No window.getComputedStyle", window.getComputedStyle);
+
+  assertTrue(elements.length > 0);
+  for (var i = 0; i < elements.length; i++) {
+    var style = window.getComputedStyle(elements[i], null);
+    assertEquals(expectedValue, style[property]);
+  }
+};
 
 /**
  * Takes in an array of strings and returns an array of floats.

--- a/auto_tests/tests/axis_labels.js
+++ b/auto_tests/tests/axis_labels.js
@@ -574,47 +574,48 @@ AxisLabelsTestCase.prototype.testAxisLabelFontSize = function() {
   assertEquals(14, Dygraph.DEFAULT_ATTRS.axisLabelFontSize);
 
   var assertFontSize = function(selector, expected) {
-    Util.assertStyleOfChildren(selector, "font-size", expected);
+    Util.assertStyleOfChildren(document.getElementsByClassName(selector),
+        "font-size", expected);
   }
-  
-  assertFontSize($(".dygraph-axis-label-x"), "14px");
-  assertFontSize($(".dygraph-axis-label-y") , "14px");
+
+  assertFontSize("dygraph-axis-label-x", "14px");
+  assertFontSize("dygraph-axis-label-y", "14px");
 
   g.updateOptions({ axisLabelFontSize : 8});
-  assertFontSize($(".dygraph-axis-label-x"), "8px"); 
-  assertFontSize($(".dygraph-axis-label-y"), "8px"); 
+  assertFontSize("dygraph-axis-label-x", "8px");
+  assertFontSize("dygraph-axis-label-y", "8px");
 
   g.updateOptions({
     axisLabelFontSize : null,
-    axes : { 
+    axes : {
       x : { axisLabelFontSize : 5 },
-    }   
-  }); 
+    }
+  });
 
-  assertFontSize($(".dygraph-axis-label-x"), "5px"); 
-  assertFontSize($(".dygraph-axis-label-y"), "14px");
+  assertFontSize("dygraph-axis-label-x", "5px");
+  assertFontSize("dygraph-axis-label-y", "14px");
 
   g.updateOptions({
-    axes : { 
+    axes : {
       y : { axisLabelFontSize : 20 },
-    }   
-  }); 
+    }
+  });
 
-  assertFontSize($(".dygraph-axis-label-x"), "5px"); 
-  assertFontSize($(".dygraph-axis-label-y"), "20px"); 
+  assertFontSize("dygraph-axis-label-x", "5px");
+  assertFontSize("dygraph-axis-label-y", "20px");
 
   g.updateOptions({
-    series : { 
+    series : {
       Y2 : { axis : "y2" } // copy y2 series to y2 axis.
-    },  
-    axes : { 
+    },
+    axes : {
       y2 : { axisLabelFontSize : 12 },
-    }   
-  }); 
+    }
+  });
 
-  assertFontSize($(".dygraph-axis-label-x"), "5px"); 
-  assertFontSize($(".dygraph-axis-label-y1"), "20px"); 
-  assertFontSize($(".dygraph-axis-label-y2"), "12px"); 
+  assertFontSize("dygraph-axis-label-x", "5px");
+  assertFontSize("dygraph-axis-label-y1", "20px");
+  assertFontSize("dygraph-axis-label-y2", "12px");
 }
 
 AxisLabelsTestCase.prototype.testAxisLabelFontSizeNull = function() {
@@ -625,14 +626,15 @@ AxisLabelsTestCase.prototype.testAxisLabelFontSizeNull = function() {
     });
 
   var assertFontSize = function(selector, expected) {
-    Util.assertStyleOfChildren(selector, "font-size", expected);
+    Util.assertStyleOfChildren(document.getElementsByClassName(selector),
+        "font-size", expected);
   };
 
   // Be sure we're dealing with a 14-point default.
   assertEquals(14, Dygraph.DEFAULT_ATTRS.axisLabelFontSize);
 
-  assertFontSize($(".dygraph-axis-label-x"), "14px");
-  assertFontSize($(".dygraph-axis-label-y"), "14px");
+  assertFontSize("dygraph-axis-label-x", "14px");
+  assertFontSize("dygraph-axis-label-y", "14px");
 }
 
 AxisLabelsTestCase.prototype.testAxisLabelColor = function() {
@@ -643,47 +645,48 @@ AxisLabelsTestCase.prototype.testAxisLabelColor = function() {
   assertEquals("black", Dygraph.DEFAULT_ATTRS.axisLabelColor);
 
   var assertColor = function(selector, expected) {
-    Util.assertStyleOfChildren(selector, "color", expected);
+    Util.assertStyleOfChildren(document.getElementsByClassName(selector),
+        "color", expected);
   }
 
-  assertColor($(".dygraph-axis-label-x"), "rgb(0, 0, 0)");
-  assertColor($(".dygraph-axis-label-y"), "rgb(0, 0, 0)");
+  assertColor("dygraph-axis-label-x", "rgb(0, 0, 0)");
+  assertColor("dygraph-axis-label-y", "rgb(0, 0, 0)");
 
   g.updateOptions({ axisLabelColor : "red"});
-  assertColor($(".dygraph-axis-label-x"), "rgb(255, 0, 0)"); 
-  assertColor($(".dygraph-axis-label-y"), "rgb(255, 0, 0)"); 
+  assertColor("dygraph-axis-label-x", "rgb(255, 0, 0)");
+  assertColor("dygraph-axis-label-y", "rgb(255, 0, 0)");
 
   g.updateOptions({
     axisLabelColor : null,
-    axes : { 
+    axes : {
       x : { axisLabelColor : "blue" },
-    }   
-  }); 
+    }
+  });
 
-  assertColor($(".dygraph-axis-label-x"), "rgb(0, 0, 255)"); 
-  assertColor($(".dygraph-axis-label-y"), "rgb(0, 0, 0)");
+  assertColor("dygraph-axis-label-x", "rgb(0, 0, 255)");
+  assertColor("dygraph-axis-label-y", "rgb(0, 0, 0)");
 
   g.updateOptions({
-    axes : { 
+    axes : {
       y : { axisLabelColor : "green" },
-    }   
-  }); 
+    }
+  });
 
-  assertColor($(".dygraph-axis-label-x"), "rgb(0, 0, 255)"); 
-  assertColor($(".dygraph-axis-label-y"), "rgb(0, 128, 0)"); 
+  assertColor("dygraph-axis-label-x", "rgb(0, 0, 255)");
+  assertColor("dygraph-axis-label-y", "rgb(0, 128, 0)");
 
   g.updateOptions({
-    series : { 
+    series : {
       Y2 : { axis : "y2" } // copy y2 series to y2 axis.
-    },  
-    axes : { 
+    },
+    axes : {
       y2 : { axisLabelColor : "yellow" },
-    }   
-  }); 
+    }
+  });
 
-  assertColor($(".dygraph-axis-label-x"), "rgb(0, 0, 255)"); 
-  assertColor($(".dygraph-axis-label-y1"), "rgb(0, 128, 0)"); 
-  assertColor($(".dygraph-axis-label-y2"), "rgb(255, 255, 0)"); 
+  assertColor("dygraph-axis-label-x", "rgb(0, 0, 255)");
+  assertColor("dygraph-axis-label-y1", "rgb(0, 128, 0)");
+  assertColor("dygraph-axis-label-y2", "rgb(255, 255, 0)");
 }
 
 AxisLabelsTestCase.prototype.testAxisLabelColorNull = function() {
@@ -694,14 +697,15 @@ AxisLabelsTestCase.prototype.testAxisLabelColorNull = function() {
     });
 
   var assertColor = function(selector, expected) {
-    Util.assertStyleOfChildren(selector, "color", expected);
+    Util.assertStyleOfChildren(document.getElementsByClassName(selector),
+        "color", expected);
   }
 
   // Be sure we're dealing with a 14-point default.
   assertEquals(14, Dygraph.DEFAULT_ATTRS.axisLabelFontSize);
 
-  assertColor($(".dygraph-axis-label-x"), "rgb(0, 0, 0)");
-  assertColor($(".dygraph-axis-label-y"), "rgb(0, 0, 0)");
+  assertColor("dygraph-axis-label-x", "rgb(0, 0, 0)");
+  assertColor("dygraph-axis-label-y", "rgb(0, 0, 0)");
 }
 
 /*


### PR DESCRIPTION
When running the tests via JsTestDriver, I was getting errors relating to $ not being defined.

```
$ java -jar ./auto_tests/lib/JsTestDriver-1.3.3c.jar --tests all
...............................EEEE...................................
..F...................................................................
......................................................................
...............................................
Total 257 tests (Passed: 252; Fails: 1; Errors: 4) (3053.00 ms)
  Chrome 29.0.1547.65 Mac OS: Run 257 tests (Passed: 252; Fails: 1; Errors 4) (3053.00 ms)
    axis-labels.testAxisLabelFontSize error (5.00 ms): TypeError: Property '$' of object [object Object] is not a function
      TypeError: Property '$' of object [object Object] is not a function
          at AxisLabelsTestCase.testAxisLabelFontSize (http://localhost:9876/test/auto_tests/tests/axis_labels.js:580:18)

    axis-labels.testAxisLabelFontSizeNull error (7.00 ms): TypeError: Property '$' of object [object Object] is not a function
      TypeError: Property '$' of object [object Object] is not a function
          at AxisLabelsTestCase.testAxisLabelFontSizeNull (http://localhost:9876/test/auto_tests/tests/axis_labels.js:634:18)

    axis-labels.testAxisLabelColor error (7.00 ms): TypeError: Property '$' of object [object Object] is not a function
      TypeError: Property '$' of object [object Object] is not a function
          at AxisLabelsTestCase.testAxisLabelColor (http://localhost:9876/test/auto_tests/tests/axis_labels.js:649:15)

    axis-labels.testAxisLabelColorNull error (7.00 ms): TypeError: Property '$' of object [object Object] is not a function
      TypeError: Property '$' of object [object Object] is not a function
          at AxisLabelsTestCase.testAxisLabelColorNull (http://localhost:9876/test/auto_tests/tests/axis_labels.js:703:15)

    custom-bars.testCustomBarsWithNegativeValuesInLogScale failed (16.00 ms): AssertError: expected 2 but was 3
      Error: expected 2 but was 3
          at CustomBarsTestCase.testCustomBarsWithNegativeValuesInLogScale (http://localhost:9876/test/auto_tests/tests/custom_bars.js:182:3)

Tests failed: Tests failed. See log for details.
```

(The custom-bars error seems to be a bit flaky - it only seems to pass the first time it's run)

I couldn't figure out where jQuery was meant to be pulled in, so I rewrote the tests to use window.getComputedStyle. This should work for all but IE8 and below (http://www.quirksmode.org/dom/w3c_css.html). I'm not sure if IE8 is supported? If it is I'll look for an alternative approach.
