### PR TITLE
Fix flaky testCustomBarsWithNegativeValuesInLogScale. 

### DIFF
--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -334,6 +334,9 @@ DygraphCanvasRenderer._drawSeries = function(e,
       point = arr[i];
     }
 
+    // FIXME: The 'canvasy != canvasy' test here catches NaN values but the test
+    // doesn't catch Infinity values. Could change this to
+    // !isFinite(point.canvasy), but I assume it avoids isNaN for performance?
     if (point.canvasy === null || point.canvasy != point.canvasy) {
       if (stepPlot && prevCanvasX !== null) {
         // Draw a horizontal line to the start of the missing data

--- a/dygraph-layout.js
+++ b/dygraph-layout.js
@@ -213,7 +213,8 @@ DygraphLayout.prototype._evaluateLimits = function() {
 
 DygraphLayout._calcYNormal = function(axis, value, logscale) {
   if (logscale) {
-    return 1.0 - ((Dygraph.log10(value) - Dygraph.log10(axis.minyval)) * axis.ylogscale);
+    var x = 1.0 - ((Dygraph.log10(value) - Dygraph.log10(axis.minyval)) * axis.ylogscale);
+    return isFinite(x) ? x : NaN;
   } else {
     return 1.0 - ((value - axis.minyval) * axis.yscale);
   }


### PR DESCRIPTION
CustomBars.testCustomBarsWithNegativeValuesInLogScale works fine the first time I start the jstd server, but subsequent runs give errors like this:

$ java -jar ./auto_tests/lib/JsTestDriver-1.3.3c.jar --tests all
......................................................................
......F...............................................................
......................................................................
....................................................
Total 262 tests (Passed: 261; Fails: 1; Errors: 0) (3730.00 ms)
  Chrome 29.0.1547.76 Mac OS: Run 262 tests (Passed: 261; Fails: 1; Errors 0) (3730.00 ms)
    custom-bars.testCustomBarsWithNegativeValuesInLogScale failed (28.00 ms): AssertError: expected 2 but was 3
      Error: expected 2 but was 3
          at CustomBarsTestCase.testCustomBarsWithNegativeValuesInLogScale (http://localhost:9876/test/auto_tests/tests/custom_bars.js:182:3)

It took a long time to track this down as the error seems to stem from a jit issue, and the problem stopped happening when stepping through the code in the debugger. Argh.

The problem is that after _calcYNormal has been run a number of times, calls with value=NaN start producing Infinity rather than NaN. For the custom bars tests, this means that _drawSeries then ends up including an extra point that's normally not rendered.

This is probably a bug in V8 but it's possible to work around the bug and make the code a bit more robust. I opted to check for Infinity in _calcYNormal but a slightly more targeted fix would be to update _drawSeries to check for finite point.canvasy and not just NaN. I'm not sure which approach you'd prefer.
