### PR TITLE
Make highlight background configurable

### DIFF
--- a/dygraph-options-reference.js
+++ b/dygraph-options-reference.js
@@ -160,6 +160,18 @@ Dygraph.OPTIONS_REFERENCE =  // <JSON>
     "type": "float",
     "description": "Fade the background while highlighting series. 1=fully visible background (disable fading), 0=hiddden background (show highlighted series only)."
   },
+  "highlightSeriesBackgroundAnim": {
+    "default": "true",
+    "labels": ["Interactive Elements"],
+    "type": "boolean",
+    "description": "Gradually fade the background while highlighting series. true = use an animation, false = fade immediately"
+  },
+  "highlightSeriesBackgroundColorRGB": {
+    "default": "255, 255, 255 (white)",
+    "labels": ["Interactive Elements"],
+    "type": "string (rgb format)",
+    "description": "Fade the background using this background color while highlighting series. Must be an RGB value, eg: '128, 196, 196'."
+  },
   "includeZero": {
     "default": "false",
     "labels": ["Axis display"],

--- a/dygraph.js
+++ b/dygraph.js
@@ -243,6 +243,8 @@ Dygraph.DEFAULT_ATTRS = {
   highlightCircleSize: 3,
   highlightSeriesOpts: null,
   highlightSeriesBackgroundAlpha: 0.5,
+  highlightSeriesBackgroundAnim: true,
+  highlightSeriesBackgroundColorRGB: '255,255,255',
 
   labelsDivWidth: 250,
   labelsDivStyles: {
@@ -1973,11 +1975,11 @@ Dygraph.prototype.updateSelection_ = function(opt_animFraction) {
   if (this.getOption('highlightSeriesOpts')) {
     ctx.clearRect(0, 0, this.width_, this.height_);
     var alpha = 1.0 - this.getNumericOption('highlightSeriesBackgroundAlpha');
+    var rgb = this.getStringOption('highlightSeriesBackgroundColorRGB');
     if (alpha) {
       // Activating background fade includes an animation effect for a gradual
-      // fade. TODO(klausw): make this independently configurable if it causes
-      // issues? Use a shared preference to control animations?
-      var animateBackgroundFade = true;
+      // fade.
+      var animateBackgroundFade = this.getBooleanOption('highlightSeriesBackgroundAnim');
       if (animateBackgroundFade) {
         if (opt_animFraction === undefined) {
           // start a new animation
@@ -1986,7 +1988,7 @@ Dygraph.prototype.updateSelection_ = function(opt_animFraction) {
         }
         alpha *= opt_animFraction;
       }
-      ctx.fillStyle = 'rgba(255,255,255,' + alpha + ')';
+      ctx.fillStyle = 'rgba(' + rgb + ',' + alpha + ')';
       ctx.fillRect(0, 0, this.width_, this.height_);
     }
 


### PR DESCRIPTION
Background color and animation while highlighting series
is now configurable using these options and defaults:
    - highlightSeriesBackgroundAnim: true
    - highlightSeriesBackgroundColorRGB: '255, 255, 255'

Updated dygraph-options-reference.js

Needed this for my project and thought it would be a good thing in general.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/danvk/dygraphs/285)
<!-- Reviewable:end -->
