### PR TITLE
Speed up renerding of stacked graph when stackedGraphNaNFill = 'none'

### DIFF
--- a/dygraph.js
+++ b/dygraph.js
@@ -2368,8 +2368,7 @@ Dygraph.stackPoints_ = function(
     if (isNaN(actualYval) || actualYval === null) {
       if(fillMethod == 'none') {
         actualYval = 0;
-      }
-      else {
+      } else {
         // Interpolate/extend for stacking purposes if possible.
         updateNextPoint(i);
         if (prevPoint && nextPoint && fillMethod != 'none') {


### PR DESCRIPTION
This is a partial fix for Issue 497:    Stacked charts with lots of data and null values are slow to render.  If stackedGraphNaNFill = 'none', we can avoid the loop in updateNextPoint, by not calling it.
