### PR TITLE
Fixed a bug where it would get the wrong extreme values for data that ha...

### DIFF
--- a/datahandler/default.js
+++ b/datahandler/default.js
@@ -84,7 +84,7 @@ DefaultHandler.prototype.getExtremeYValues = function(series, dateWindow,
   var firstIdx = 0, lastIdx = series.length - 1;
 
   for ( var j = firstIdx; j <= lastIdx; j++) {
-    y = series[j][1];
+    y = parseFloat(series[j][1]);
     if (y === null || isNaN(y))
       continue;
     if (maxY === null || y > maxY) {


### PR DESCRIPTION
If your data is passed in via strings the comparator would fail on a comparison similar to "72.6" > "321.4"

This would distort the graph and give you the incorrect extremes. 
