### PR TITLE
Added support for UTC date time labels.

### DIFF
--- a/dygraph-utils.js
+++ b/dygraph-utils.js
@@ -477,45 +477,72 @@ Dygraph.zeropad = function(x) {
 
 /**
  * Return a string version of the hours, minutes and seconds portion of a date.
- *
  * @param {number} date The JavaScript date (ms since epoch)
- * @return {string} A time of the form "HH:MM:SS"
+ * @param {boolean} utc Wether output UTC or local time
+ * @return {string} A time of the form "HH:MM" or "HH:MM:SS"
  * @private
  */
-Dygraph.hmsString_ = function(date) {
+Dygraph.hmsString_ = function(date, utc) {
   var zeropad = Dygraph.zeropad;
-  var d = new Date(date);
-  if (d.getSeconds()) {
-    return zeropad(d.getHours()) + ":" +
-           zeropad(d.getMinutes()) + ":" +
-           zeropad(d.getSeconds());
+  var dt = new Date(date);
+  var hh, mm, ss;
+  if (utc) {
+    hh = dt.getUTCHours();
+    mm = dt.getUTCMinutes();
+    ss = dt.getUTCSeconds();
   } else {
-    return zeropad(d.getHours()) + ":" + zeropad(d.getMinutes());
+    hh = dt.getHours();
+    mm = dt.getMinutes();
+    ss = dt.getSeconds();
+  }
+  if (ss) {
+    return zeropad(hh) + ":" + zeropad(mm) + ":" + zeropad(ss);
+  } else {
+    return zeropad(hh) + ":" + zeropad(mm);
   }
 };
 
 /**
  * Convert a JS date (millis since epoch) to YYYY/MM/DD
  * @param {number} date The JavaScript date (ms since epoch)
- * @return {string} A date of the form "YYYY/MM/DD"
+ * @param {boolean} utc Wether output UTC or local time
+ * @return {string} A date of one of these forms:
+ *     "YYYY/MM/DD", "YYYY/MM/DD HH:MM" or "YYYY/MM/DD HH:MM:SS"
  * @private
  */
-Dygraph.dateString_ = function(date) {
+Dygraph.dateString_ = function(date, utc) {
   var zeropad = Dygraph.zeropad;
-  var d = new Date(date);
-
-  // Get the year:
-  var year = "" + d.getFullYear();
+  var dt = new Date(date);
+  var y, m, d, hh, mm, ss;
+  if (utc) {
+    y = dt.getUTCFullYear();
+    m = dt.getUTCMonth();
+    d = dt.getUTCDate();
+    hh = dt.getUTCHours();
+    mm = dt.getUTCMinutes();
+    ss = dt.getUTCSeconds();
+  } else {
+    y = dt.getFullYear();
+    m = dt.getMonth();
+    d = dt.getDate();
+    hh = dt.getHours();
+    mm = dt.getMinutes();
+    ss = dt.getSeconds();
+  }
+  // Get a year string:
+  var year = "" + y;
   // Get a 0 padded month string
-  var month = zeropad(d.getMonth() + 1);  //months are 0-offset, sigh
+  var month = zeropad(m + 1);  //months are 0-offset, sigh
   // Get a 0 padded day string
-  var day = zeropad(d.getDate());
-
-  var ret = "";
-  var frac = d.getHours() * 3600 + d.getMinutes() * 60 + d.getSeconds();
-  if (frac) ret = " " + Dygraph.hmsString_(date);
-
-  return year + "/" + month + "/" + day + ret;
+  var day = zeropad(d);
+  var frac = hh * 3600 + mm * 60 + ss;
+  var ret = year + "/" + month + "/" + day;
+  if (ss) {
+    ret += " " + zeropad(hh) + ":" + zeropad(mm) + ":" + zeropad(ss);
+  } else if (frac) {
+    ret += " " + zeropad(hh) + ":" + zeropad(mm);
+  }
+  return ret;
 };
 
 /**


### PR DESCRIPTION
- dygraph-utils.js:
  new utc switch parameter for `Dygraph.hmsString_`
  and `Dygraph.dateString_`.
- dygraph.js:
     new utc date axis formater `Dygraph.dateUTCAxisFormatter`.

The `dateUTCAxisFormatter` provided is just a copy of the orginal `dateAxisFormatter`,
but using UTC date functions instead of the local time ones.
An alternative approach is to add an `utc` boolean parameter and the related logic
into the `dateAxisFormatter` function (as in `Dygraph.hmsString_` in `dygraph-utils.js`) 
and provide the following specializations:

``` js
Dygraph.dateUTCAxisFormatter = function(date, granularity) {
   return Dygraph.dateAxisFormatter(date, granularity, true)
}

Dygraph.dateLocalTimeAxisFormatter = function(date, granularity) {
  return Dygraph.dateAxisFormatter(date, granularity, false)
}
```

I (@joanpau) am not sure if the modified `dateAxisFormatter` would be backwards 
compatible then (would the third parameter break some formatter interface?). 
If it was, the local time specialization would not be needed.
