### PR TITLE
Fix bad 'g' argument for drawHighlightPointCallback.

### DIFF
--- a/dygraph.js
+++ b/dygraph.js
@@ -2027,7 +2027,7 @@ Dygraph.prototype.updateSelection_ = function(opt_animFraction) {
       ctx.lineWidth = this.getNumericOption('strokeWidth', pt.name);
       ctx.strokeStyle = color;
       ctx.fillStyle = color;
-      callback(this.g, pt.name, ctx, canvasx, pt.canvasy,
+      callback(this, pt.name, ctx, canvasx, pt.canvasy,
           color, circleSize, pt.idx);
     }
     ctx.restore();


### PR DESCRIPTION
See https://groups.google.com/d/topic/dygraphs-users/2KGnXNVNE-c/discussion for context:

> As per http://dygraphs.com/options.html#drawHighlightPointCallback,
> the first argument supplied to the callback function should be: g: the reference graph.
> 
> In the case of drawPointCallback g is indeed supplied.
> 
> But in the case of drawHighlightPointCallback, I am seeing g being undefined.
