### PR TITLE
Fix HiDPI over-scrolling issue

### DIFF
--- a/auto_tests/misc/local.html
+++ b/auto_tests/misc/local.html
@@ -62,6 +62,7 @@
   <script type="text/javascript" src="../tests/resize.js"></script>
   <script type="text/javascript" src="../tests/plugins_legend.js"></script>
   <script type="text/javascript" src="../tests/two_digit_years.js"></script>
+  <script type="text/javascript" src="../tests/hidpi.js"></script>
   <script type="text/javascript" src="../tests/update_options.js"></script>
   <script type="text/javascript" src="../tests/update_while_panning.js"></script>
   <script type="text/javascript" src="../tests/utils_test.js"></script>

--- a/auto_tests/tests/hidpi.js
+++ b/auto_tests/tests/hidpi.js
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Tests for window.devicePixelRatio > 1.
+ *
+ * @author danvdk@gmail.com (Dan Vanderkam)
+ */
+var hidpiTestCase = TestCase("hidpi");
+
+var savePixelRatio;
+hidpiTestCase.prototype.setUp = function() {
+  savePixelRatio = window.devicePixelRatio;
+  window.devicePixelRatio = 2;
+
+  document.body.innerHTML = "<div id='graph'></div>";
+};
+
+hidpiTestCase.prototype.tearDown = function() {
+  window.devicePixelRatio = savePixelRatio;
+};
+
+hidpiTestCase.prototype.testNameGoesHere = function() {
+  var graph = document.getElementById("graph");
+  graph.style.width = "70%";  // more than half.
+  graph.style.height = "200px";
+
+  var opts = {};
+  var data = "X,Y\n" +
+      "0,-1\n" +
+      "1,0\n" +
+      "2,1\n" +
+      "3,0\n"
+  ;
+
+  var g = new Dygraph(graph, data, opts);
+
+  // See http://stackoverflow.com/a/2146905/388951
+  var hasHorizontalScrollbar = (document.body.scrollWidth > document.body.clientWidth);
+  assertEquals(false, hasHorizontalScrollbar);
+};
+

--- a/dygraph-canvas.js
+++ b/dygraph-canvas.js
@@ -52,7 +52,6 @@ var DygraphCanvasRenderer = function(dygraph, element, elementContext, layout) {
   this.layout = layout;
   this.element = element;
   this.elementContext = elementContext;
-  this.container = this.element.parentNode;
 
   this.height = this.element.height;
   this.width = this.element.width;
@@ -64,8 +63,6 @@ var DygraphCanvasRenderer = function(dygraph, element, elementContext, layout) {
 
   // internal state
   this.area = layout.getPlotArea();
-  this.container.style.position = "relative";
-  this.container.style.width = this.width + "px";
 
   // Set up a clipping area for the canvas (and the interaction canvas).
   // This ensures that we don't overdraw.

--- a/dygraph.js
+++ b/dygraph.js
@@ -1104,6 +1104,7 @@ Dygraph.prototype.createInterface_ = function() {
 
   // TODO(danvk): any other styles that are useful to set here?
   this.graphDiv.style.textAlign = 'left';  // This is a CSS "reset"
+  this.graphDiv.style.position = 'relative';
   enclosing.appendChild(this.graphDiv);
 
   // Create the canvas for interactive parts of the chart.


### PR DESCRIPTION
If you visit https://rawgit.com/danvk/dygraphs/master/tests/demo.html on a "retina" device and shrink the window to match the width of the chart, you'll find that there's a mysterious horizontal scroll bar.

This was due to dygraph-canvas.js mysteriously re-setting the width of g.graphDiv. It's not clear why it would do this, since it's already been set in Dygraph.prototype.resizeElements_. It's also unclear why it would set the width and not the height. I'm guessing this is a relic -- the tests pass with the line removed.
