### PR TITLE
Replace '&nbsp;' with '&#160;', so that the legend works in XHTML pages

### DIFF
--- a/plugins/legend.js
+++ b/plugins/legend.js
@@ -249,7 +249,7 @@ generateLegendHTML = function(g, x, sel_points, oneEmWidth) {
 
     // TODO(danvk): use a template string here and make it an attribute.
     html += "<span" + cls + ">" + " <b><span style='color: " + series.color + ";'>" +
-        escapeHTML(pt.name) + "</span></b>:&nbsp;" + yval + "</span>";
+        escapeHTML(pt.name) + "</span></b>:&#160;" + yval + "</span>";
   }
   return html;
 };


### PR DESCRIPTION
If dyGraph is used in an XHTML document (delivered with Content-Type application/xhtml+xml), the mouseover effect which shows the legend won't work. This is due to the usage of the `&nbsp;` which is an undefined entity in XML. instead `&#160;` does exactly the same, but works in XHTML pages as well.
