### PR TITLE
Add missing license text to dygraph-externs.js and dygraph-types.js

### DIFF
--- a/dygraph-externs.js
+++ b/dygraph-externs.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2006 Dan Vanderkam (danvdk@gmail.com)
+ * MIT-licensed (http://opensource.org/licenses/MIT)
+ */
+
 // TODO(danvk): move the Dygraph definitions out of here once I closure-ify dygraphs.js
 /**
  * @param {!HTMLDivElement|string} div

--- a/dygraph-types.js
+++ b/dygraph-types.js
@@ -1,3 +1,9 @@
+/**
+ * @license
+ * Copyright 2006 Dan Vanderkam (danvdk@gmail.com)
+ * MIT-licensed (http://opensource.org/licenses/MIT)
+ */
+
 // This file contains typedefs and externs that are needed by the Closure Compiler.
 
 /**


### PR DESCRIPTION
Add some missing @license text.
