### PR TITLE
Add highlightMinDistance option

### DIFF
--- a/auto_tests/tests/callback.js
+++ b/auto_tests/tests/callback.js
@@ -529,7 +529,7 @@ CallbackTestCase.prototype.testFailedResponse = function() {
 };
 
 
-// Regression test for http://code.google.com/p/dygraphs/issues/detail?id=355 
+// Regression test for http://code.google.com/p/dygraphs/issues/detail?id=355
 CallbackTestCase.prototype.testHighlightCallbackRow = function() {
   var highlightRow;
   var highlightCallback = function(e, x, pts, row) {
@@ -672,7 +672,7 @@ CallbackTestCase.prototype.testDrawPointCallback_idx = function() {
 CallbackTestCase.prototype.testDrawHighlightPointCallback_idx = function() {
     var idxToCheck = null;
 
-    var drawHighlightPointCallback  = function(g, seriesName, canvasContext, cx, cy, color, pointSizeParam,idx) {
+    var drawHighlightPointCallback  = function(g, seriesName, canvasContext, cx, cy, color, pointSizeParam, idx) {
         idxToCheck = idx;
     };
     var testdata = [[1, 2], [2, 3], [3, NaN], [4, 2], [5, NaN], [6, 3]];
@@ -691,4 +691,36 @@ CallbackTestCase.prototype.testDrawHighlightPointCallback_idx = function() {
     assertEquals(0,idxToCheck);
     DygraphOps.dispatchMouseMove(g, 6, 3);
     assertEquals(5,idxToCheck);
+};
+
+/**
+ * Test that highlight min distance works
+  */
+CallbackTestCase.prototype.testhighlightMinDistance= function() {
+    var idxToCheck = null;
+
+    var drawHighlightPointCallback  = function(g, seriesName, canvasContext, cx, cy, color, pointSizeParam, idx) {
+        idxToCheck = idx;
+    };
+    var testdata = [[1, 2], [15, 15]];
+    var graph = document.getElementById("graph");
+    var g = new Dygraph(graph, testdata,
+        {
+            drawHighlightPointCallback: drawHighlightPointCallback,
+            // Distance in pixels
+            highlightMinDistance: 50
+        });
+
+    assertNull(idxToCheck);
+    DygraphOps.dispatchMouseMove(g, 300, 300);
+    // Check that far away point is not returned
+    assertNull(idxToCheck);
+    DygraphOps.dispatchMouseMove(g, 2, 2);
+    // Check that the first index is returned
+    assertEquals(0, idxToCheck);
+    DygraphOps.dispatchMouseMove(g, 7, 7);
+    // Check that idx is not changed
+    assertEquals(0, idxToCheck);
+    DygraphOps.dispatchMouseMove(g, 14, 14);
+    assertEquals(1, idxToCheck);
 };

--- a/auto_tests/tests/callback.js
+++ b/auto_tests/tests/callback.js
@@ -363,7 +363,7 @@ CallbackTestCase.prototype.testNaNData = function() {
 
   // Explicitly test closest point algorithms
   var dom = g.toDomCoords(10.1, 0.9);
-  assertEquals(1, g.findClosestRow(dom[0]));
+  assertEquals(1, g.findClosestRow(dom[0], dom[1]));
 
   var res = g.findClosestPoint(dom[0], dom[1]);
   assertEquals(1, res.row);

--- a/auto_tests/tests/update_options.js
+++ b/auto_tests/tests/update_options.js
@@ -5,7 +5,7 @@
  * @author antrob@google.com (Anthony Robledo)
  */
 var UpdateOptionsTestCase = TestCase("update-options");
-  
+
 UpdateOptionsTestCase.prototype.opts = {
   width: 480,
   height: 320,
@@ -76,7 +76,7 @@ UpdateOptionsTestCase.prototype.testStrokeSingleSeries = function() {
   this.unwrapDrawGraph(graph);
   assertFalse(graph._testDrawCalled);
 };
- 
+
 UpdateOptionsTestCase.prototype.testSingleSeriesRequiresNewPoints = function() {
   var graphDiv = document.getElementById("graph");
   var graph = new Dygraph(graphDiv, this.data, this.opts);
@@ -122,6 +122,17 @@ UpdateOptionsTestCase.prototype.testUpdateLabelsDivDoesntInfiniteLoop = function
   var labelsDiv = document.getElementById("labels");
   var graph = new Dygraph(graphDiv, this.data, this.opts);
   graph.updateOptions({labelsDiv : labelsDiv});
+}
+
+// Test https://github.com/danvk/dygraphs/pull/311
+UpdateOptionsTestCase.prototype.testUpdateHighlightMinDistance = function() {
+  var graphDiv = document.getElementById("graph");
+  var graph = new Dygraph(graphDiv, this.data, this.opts);
+  assertEquals(Infinity, graph.getNumericOption('highlightMinDistance'));
+  graph.updateOptions({ highlightMinDistance : 100 });
+  assertEquals(100, graph.getNumericOption('highlightMinDistance'));
+  graph.updateOptions({ highlightMinDistance : Infinity });
+  assertEquals(Infinity, graph.getNumericOption('highlightMinDistance'));
 }
 
 // Test https://github.com/danvk/dygraphs/issues/247

--- a/dygraph-options-reference.js
+++ b/dygraph-options-reference.js
@@ -148,6 +148,12 @@ Dygraph.OPTIONS_REFERENCE =  // <JSON>
     ],
     "description": "Draw a custom item when a point is highlighted.  Default is a small dot matching the series color. This method should constrain drawing to within pointSize pixels from (cx, cy) Also see <a href='#drawPointCallback'>drawPointCallback</a>"
   },
+  "highlightMinDistance": {
+    "default": "Infinity",
+    "labels": ["Interactive Elements"],
+    "type": "Object",
+    "description": "Minimum distance in pixels to highlight a series."
+  },
   "highlightSeriesOpts": {
     "default": "null",
     "labels": ["Interactive Elements"],

--- a/dygraph.js
+++ b/dygraph.js
@@ -1043,7 +1043,7 @@ Dygraph.prototype.toPercentXCoord = function(x) {
   var xRange = this.xAxisRange();
   var pct;
   var logscale = this.attributes_.getForAxis("logscale", 'x') ;
-  if (logscale == true) { // logscale can be null so we test for true explicitly.
+  if (logscale === true) { // logscale can be null so we test for true explicitly.
     var logr0 = Dygraph.log10(xRange[0]);
     var logr1 = Dygraph.log10(xRange[1]);
     pct = (Dygraph.log10(x) - logr0) / (logr1 - logr0);
@@ -1828,7 +1828,7 @@ Dygraph.prototype.findClosestRow = function(domX, domY) {
       var dx = point.canvasx - domX;
       var dy = point.canvasy - domY;
       var euclideanDist = Math.sqrt(dx * dx + dy * dy);
-      if (dist < minDistX && euclideanDist < highlightMinDistance) {
+      if (dist < minDistX && (isNaN(euclideanDist) || euclideanDist < highlightMinDistance)) {
         minDistX = dist;
         closestRow = point.idx;
       }
@@ -1862,7 +1862,7 @@ Dygraph.prototype.findClosestPoint = function(domX, domY) {
       dx = point.canvasx - domX;
       dy = point.canvasy - domY;
       dist = dx * dx + dy * dy;
-      if (dist < minDist && dist < highlightMinDistance) {
+      if (dist < minDist && (isNaN(dist) || dist < highlightMinDistance)) {
         minDist = dist;
         closestPoint = point;
         closestSeries = setIdx;

--- a/dygraph.js
+++ b/dygraph.js
@@ -241,6 +241,7 @@ Dygraph.Plotters = DygraphCanvasRenderer._Plotters;
 // Default attribute values.
 Dygraph.DEFAULT_ATTRS = {
   highlightCircleSize: 3,
+  highlightMinDistance: Infinity,
   highlightSeriesOpts: null,
   highlightSeriesBackgroundAlpha: 0.5,
 
@@ -1812,8 +1813,9 @@ Dygraph.prototype.eventToDomCoords = function(event) {
  * Returns {number} row number.
  * @private
  */
-Dygraph.prototype.findClosestRow = function(domX) {
+Dygraph.prototype.findClosestRow = function(domX, domY) {
   var minDistX = Infinity;
+  var highlightMinDistance = this.getNumericOption('highlightMinDistance');
   var closestRow = -1;
   var sets = this.layout_.points;
   for (var i = 0; i < sets.length; i++) {
@@ -1823,7 +1825,10 @@ Dygraph.prototype.findClosestRow = function(domX) {
       var point = points[j];
       if (!Dygraph.isValidPoint(point, true)) continue;
       var dist = Math.abs(point.canvasx - domX);
-      if (dist < minDistX) {
+      var dx = point.canvasx - domX;
+      var dy = point.canvasy - domY;
+      var euclideanDist = Math.sqrt(dx * dx + dy * dy);
+      if (dist < minDistX && euclideanDist < highlightMinDistance) {
         minDistX = dist;
         closestRow = point.idx;
       }
@@ -1847,6 +1852,7 @@ Dygraph.prototype.findClosestRow = function(domX) {
  */
 Dygraph.prototype.findClosestPoint = function(domX, domY) {
   var minDist = Infinity;
+  var highlightMinDistance = this.getNumericOption('highlightMinDistance');
   var dist, dx, dy, point, closestPoint, closestSeries, closestRow;
   for ( var setIdx = this.layout_.points.length - 1 ; setIdx >= 0 ; --setIdx ) {
     var points = this.layout_.points[setIdx];
@@ -1856,7 +1862,7 @@ Dygraph.prototype.findClosestPoint = function(domX, domY) {
       dx = point.canvasx - domX;
       dy = point.canvasy - domY;
       dist = dx * dx + dy * dy;
-      if (dist < minDist) {
+      if (dist < minDist && dist < highlightMinDistance) {
         minDist = dist;
         closestPoint = point;
         closestSeries = setIdx;
@@ -1885,7 +1891,7 @@ Dygraph.prototype.findClosestPoint = function(domX, domY) {
  * @private
  */
 Dygraph.prototype.findStackedPoint = function(domX, domY) {
-  var row = this.findClosestRow(domX);
+  var row = this.findClosestRow(domX, domY);
   var closestPoint, closestSeries;
   for (var setIdx = 0; setIdx < this.layout_.points.length; ++setIdx) {
     var boundary = this.getLeftBoundary_(setIdx);
@@ -1918,8 +1924,8 @@ Dygraph.prototype.findStackedPoint = function(domX, domY) {
     }
     // Stop if the point (domX, py) is above this series' upper edge
     if (setIdx === 0 || py < domY) {
-      closestPoint = p1;
-      closestSeries = setIdx;
+        closestPoint = p1;
+        closestSeries = setIdx;
     }
   }
   var name = this.layout_.setNames[closestSeries];
@@ -1957,7 +1963,7 @@ Dygraph.prototype.mouseMove_ = function(event) {
     }
     selectionChanged = this.setSelection(closest.row, closest.seriesName);
   } else {
-    var idx = this.findClosestRow(canvasx);
+    var idx = this.findClosestRow(canvasx, canvasy);
     selectionChanged = this.setSelection(idx);
   }
 
@@ -1972,7 +1978,7 @@ Dygraph.prototype.mouseMove_ = function(event) {
 };
 
 /**
- * Fetch left offset from the specified set index or if not passed, the 
+ * Fetch left offset from the specified set index or if not passed, the
  * first defined boundaryIds record (see bug #236).
  * @private
  */
@@ -2298,7 +2304,7 @@ Dygraph.prototype.getHandlerClass_ = function() {
  */
 Dygraph.prototype.predraw_ = function() {
   var start = new Date();
-  
+
   // Create the correct dataHandler
   this.dataHandler_ = new (this.getHandlerClass_())();
 
@@ -2341,7 +2347,7 @@ Dygraph.prototype.predraw_ = function() {
     if (this.rollPeriod_ > 1) {
       series = this.dataHandler_.rollingAverage(series, this.rollPeriod_, this.attributes_);
     }
-    
+
     this.rolledSeries_.push(series);
   }
 
@@ -2499,7 +2505,7 @@ Dygraph.prototype.gatherDatasets_ = function(rolledSeries, dateWindow) {
   var extremes = {};  // series name -> [low, high]
   var seriesIdx, sampleIdx;
   var firstIdx, lastIdx;
-  
+
   // Loop over the fields (series).  Go from the last to the first,
   // because if they're stacked that's how we accumulate the values.
   var num_series = rolledSeries.length - 1;
@@ -2517,7 +2523,7 @@ Dygraph.prototype.gatherDatasets_ = function(rolledSeries, dateWindow) {
 
       // TODO(danvk): do binary search instead of linear search.
       // TODO(danvk): pass firstIdx and lastIdx directly to the renderer.
-      firstIdx = null; 
+      firstIdx = null;
       lastIdx = null;
       for (sampleIdx = 0; sampleIdx < series.length; sampleIdx++) {
         if (series[sampleIdx][0] >= low && firstIdx === null) {
@@ -2551,9 +2557,9 @@ Dygraph.prototype.gatherDatasets_ = function(rolledSeries, dateWindow) {
       if (correctedLastIdx !== lastIdx) {
         lastIdx = correctedLastIdx;
       }
-      
+
       boundaryIds[seriesIdx-1] = [firstIdx, lastIdx];
-      
+
       // .slice's end is exclusive, we want to include lastIdx.
       series = series.slice(firstIdx, lastIdx + 1);
     } else {
@@ -2562,10 +2568,10 @@ Dygraph.prototype.gatherDatasets_ = function(rolledSeries, dateWindow) {
     }
 
     var seriesName = this.attr_("labels")[seriesIdx];
-    var seriesExtremes = this.dataHandler_.getExtremeYValues(series, 
+    var seriesExtremes = this.dataHandler_.getExtremeYValues(series,
         dateWindow, this.getBooleanOption("stepPlot",seriesName));
 
-    var seriesPoints = this.dataHandler_.seriesToPoints(series, 
+    var seriesPoints = this.dataHandler_.seriesToPoints(series,
         seriesName, boundaryIds[seriesIdx-1][0]);
 
     if (this.getBooleanOption("stackedGraph")) {
@@ -2777,7 +2783,7 @@ Dygraph.prototype.computeYAxisRanges_ = function(extremes) {
   };
   var numAxes = this.attributes_.numAxes();
   var ypadCompat, span, series, ypad;
-  
+
   var p_axis;
 
   // Compute extreme values, a span and tick marks for each axis.
@@ -2903,8 +2909,8 @@ Dygraph.prototype.computeYAxisRanges_ = function(extremes) {
     } else {
       axis.computedValueRange = axis.extremeRange;
     }
-    
-    
+
+
     if (independentTicks) {
       axis.independentTicks = independentTicks;
       var opts = this.optionsViewForAxis_('y' + (i ? '2' : ''));
@@ -2926,7 +2932,7 @@ Dygraph.prototype.computeYAxisRanges_ = function(extremes) {
   // independent ticks, then that is permissible as well.
   for (var i = 0; i < numAxes; i++) {
     var axis = this.axes_[i];
-    
+
     if (!axis.independentTicks) {
       var opts = this.optionsViewForAxis_('y' + (i ? '2' : ''));
       var ticker = opts('ticker');

--- a/dygraph.js
+++ b/dygraph.js
@@ -1828,7 +1828,8 @@ Dygraph.prototype.findClosestRow = function(domX, domY) {
       var dx = point.canvasx - domX;
       var dy = point.canvasy - domY;
       var euclideanDist = Math.sqrt(dx * dx + dy * dy);
-      if (dist < minDistX && (isNaN(euclideanDist) || euclideanDist < highlightMinDistance)) {
+      if (dist < minDistX && (isNaN(point.canvasx) || isNaN(point.canvasy) || isNaN(domX)
+          || isNaN(domY) || euclideanDist < highlightMinDistance)) {
         minDistX = dist;
         closestRow = point.idx;
       }
@@ -1862,7 +1863,8 @@ Dygraph.prototype.findClosestPoint = function(domX, domY) {
       dx = point.canvasx - domX;
       dy = point.canvasy - domY;
       dist = dx * dx + dy * dy;
-      if (dist < minDist && (isNaN(dist) || dist < highlightMinDistance)) {
+      if (dist < minDist && (isNaN(point.canvasx) || isNaN(point.canvasy) || isNaN(domX)
+          || isNaN(domY) || dist < highlightMinDistance)) {
         minDist = dist;
         closestPoint = point;
         closestSeries = setIdx;

--- a/dygraph.js
+++ b/dygraph.js
@@ -1828,8 +1828,7 @@ Dygraph.prototype.findClosestRow = function(domX, domY) {
       var dx = point.canvasx - domX;
       var dy = point.canvasy - domY;
       var euclideanDist = Math.sqrt(dx * dx + dy * dy);
-      if (dist < minDistX && (isNaN(point.canvasx) || isNaN(point.canvasy) || isNaN(domX)
-          || isNaN(domY) || euclideanDist < highlightMinDistance)) {
+      if (dist < minDistX && !isNaN(euclideanDist) && euclideanDist < highlightMinDistance) {
         minDistX = dist;
         closestRow = point.idx;
       }
@@ -1863,8 +1862,7 @@ Dygraph.prototype.findClosestPoint = function(domX, domY) {
       dx = point.canvasx - domX;
       dy = point.canvasy - domY;
       dist = dx * dx + dy * dy;
-      if (dist < minDist && (isNaN(point.canvasx) || isNaN(point.canvasy) || isNaN(domX)
-          || isNaN(domY) || dist < highlightMinDistance)) {
+      if (dist < minDist && !isNaN(euclideanDist) && dist < highlightMinDistance) {
         minDist = dist;
         closestPoint = point;
         closestSeries = setIdx;


### PR DESCRIPTION
This new option is required to only highlight a point if the distance is smaller than a specified distance in pixels. The default is Infinity (which doesn't change the existing behaviour in any way). This is useful for e.g. creating scatter plots and adding interaction to clicking the points.

Without this option a point is highlighted even if it's not in clicking distance.