### PR TITLE
New option 'rangeSelectorPlotFillGradientColor' (e.g. for using dygraphs on a dark background)

### DIFF
--- a/auto_tests/tests/range_selector.js
+++ b/auto_tests/tests/range_selector.js
@@ -114,6 +114,7 @@ RangeSelectorTestCase.prototype.testRangeSelectorOptions = function() {
     height: 320,
     showRangeSelector: true,
     rangeSelectorHeight: 30,
+    rangeSelectorPlotFillGradientColor: 'rgba(200, 200, 42, 10)',
     rangeSelectorPlotFillColor: 'lightyellow',
     rangeSelectorPlotStyleColor: 'yellow',
     labels: ['X', 'Y']

--- a/dygraph-options-reference.js
+++ b/dygraph-options-reference.js
@@ -793,6 +793,12 @@ Dygraph.OPTIONS_REFERENCE =  // <JSON>
     "type": "string",
     "description": "The range selector mini plot fill color. This can be of the form \"#AABBCC\" or \"rgb(255,100,200)\" or \"yellow\". You can also specify null or \"\" to turn off fill."
   },
+  "rangeSelectorPlotFillGradientColor": {
+    "default": "white",
+    "labels": ["Interactive Elements"],
+    "type": "string",
+    "description": "The second color for the range selector mini plot fill color gradient. This can be of the form \"#AABBCC\" or \"rgb(255,100,200)\" or \"rgba(255,100,200,42)\" or \"yellow\". You can also specify null or \"\" to disable the gradient and fill with one single color."
+  },
   "animatedZooms": {
     "default": "false",
     "labels": ["Interactive Elements"],

--- a/dygraph-options-reference.js
+++ b/dygraph-options-reference.js
@@ -797,7 +797,7 @@ Dygraph.OPTIONS_REFERENCE =  // <JSON>
     "default": "white",
     "labels": ["Interactive Elements"],
     "type": "string",
-    "description": "The second color for the range selector mini plot fill color gradient. This can be of the form \"#AABBCC\" or \"rgb(255,100,200)\" or \"rgba(255,100,200,42)\" or \"yellow\". You can also specify null or \"\" to disable the gradient and fill with one single color."
+    "description": "The top color for the range selector mini plot fill color gradient. This can be of the form \"#AABBCC\" or \"rgb(255,100,200)\" or \"rgba(255,100,200,42)\" or \"yellow\". You can also specify null or \"\" to disable the gradient and fill with one single color."
   },
   "animatedZooms": {
     "default": "false",

--- a/dygraph-utils.js
+++ b/dygraph-utils.js
@@ -993,6 +993,7 @@ Dygraph.isPixelChangingOptionList = function(labels, attrs) {
     'pointClickCallback': true,
     'pointSize': true,
     'rangeSelectorPlotFillColor': true,
+    'rangeSelectorPlotFillGradientColor': true,
     'rangeSelectorPlotStrokeColor': true,
     'showLabelsOnHighlight': true,
     'showRoller': true,

--- a/dygraph.js
+++ b/dygraph.js
@@ -320,6 +320,7 @@ Dygraph.DEFAULT_ATTRS = {
   rangeSelectorHeight: 40,
   rangeSelectorPlotStrokeColor: "#808FAB",
   rangeSelectorPlotFillColor: "#A7B1C4",
+  rangeSelectorPlotFillGradientColor: "white",
 
   // The ordering here ensures that central lines always appear above any
   // fill bars/error bars.

--- a/gallery/range-selector.js
+++ b/gallery/range-selector.js
@@ -11,7 +11,12 @@ Gallery.register(
           "<div id='noroll' style='width:600px; height:300px;'></div>",
           "",
           "<p>Roll period of 14 timesteps, custom range selector height and plot color.</p>",
-          "<div id='roll14' style='width:600px; height:300px;'></div>"].join("\n");
+          "<div id='roll14' style='width:600px; height:300px;'></div>",
+          "",
+          "<div style='background-color: #101015; color: white'>",
+          "<p>Dark background, custom range selector gradient color.</p>",
+          "<div id='darkbg' style='width:600px; height:300px;'></div>",
+          "</div>"].join("\n");
     },
     run: function() {
       new Dygraph(
@@ -41,6 +46,26 @@ Gallery.register(
             rangeSelectorHeight: 30,
             rangeSelectorPlotStrokeColor: 'yellow',
             rangeSelectorPlotFillColor: 'lightyellow'
-          });
+          }
+      );
+      new Dygraph(
+          document.getElementById("darkbg"),
+          data_temp,
+          {
+            rollPeriod: 14,
+            showRoller: true,
+            customBars: true,
+            title: 'Nightly Temperatures in New York vs. San Francisco',
+            ylabel: 'Temperature (F)',
+            legend: 'always',
+            labelsDivStyles: { 'textAlign': 'right', 'backgroundColor': '#101015' },
+            showRangeSelector: true,
+            rangeSelectorPlotFillColor: 'MediumSlateBlue',
+            rangeSelectorPlotFillGradientColor: 'rgba(123, 104, 238, 0)',
+            axisLabelColor: 'white',
+            colorValue: 0.9,
+            fillAlpha: 0.4
+          }
+      );
     }
   });

--- a/plugins/range-selector.js
+++ b/plugins/range-selector.js
@@ -625,7 +625,7 @@ rangeSelector.prototype.drawMiniPlot_ = function() {
   if (fillStyle) {
     var lingrad = this.bgcanvas_ctx_.createLinearGradient(0, 0, 0, canvasHeight);
     if (fillGradientStyle) {
-        lingrad.addColorStop(0, fillGradientStyle);
+      lingrad.addColorStop(0, fillGradientStyle);
     }
     lingrad.addColorStop(1, fillStyle);
     this.bgcanvas_ctx_.fillStyle = lingrad;

--- a/plugins/range-selector.js
+++ b/plugins/range-selector.js
@@ -565,6 +565,7 @@ rangeSelector.prototype.drawStaticLayer_ = function() {
  */
 rangeSelector.prototype.drawMiniPlot_ = function() {
   var fillStyle = this.getOption_('rangeSelectorPlotFillColor');
+  var fillGradientStyle = this.getOption_('rangeSelectorPlotFillGradientColor');
   var strokeStyle = this.getOption_('rangeSelectorPlotStrokeColor');
   if (!fillStyle && !strokeStyle) {
     return;
@@ -623,7 +624,9 @@ rangeSelector.prototype.drawMiniPlot_ = function() {
 
   if (fillStyle) {
     var lingrad = this.bgcanvas_ctx_.createLinearGradient(0, 0, 0, canvasHeight);
-    lingrad.addColorStop(0, 'white');
+    if (fillGradientStyle) {
+        lingrad.addColorStop(0, fillGradientStyle);
+    }
     lingrad.addColorStop(1, fillStyle);
     this.bgcanvas_ctx_.fillStyle = lingrad;
     ctx.fill();

--- a/tests/range-selector.html
+++ b/tests/range-selector.html
@@ -17,6 +17,10 @@
     #bordered {
       border: 1px solid red;
     }
+    #dark-background {
+      background-color: #101015;
+      color: white;
+    }
     </style>
   </head>
   <body>
@@ -33,7 +37,7 @@
       Demo of range selecor without the chart. (interesting if multiple charts should be synced with one range selector).
     </p>
     <div id="nochart" style="width:800px; height:30px;"></div>
-    <div style="background-color: #101015; color: white">
+    <div id="dark-background">
       <p>Demo of range selector on dark background, with (left) and without (right) custom range selector gradient color.</p>
       <div id="darkbg1" style="width:400px; height:300px;display:inline-block;"></div>
       <div id="darkbg2" style="width:400px; height:300px;display:inline-block;"></div>

--- a/tests/range-selector.html
+++ b/tests/range-selector.html
@@ -33,6 +33,12 @@
       Demo of range selecor without the chart. (interesting if multiple charts should be synced with one range selector).
     </p>
     <div id="nochart" style="width:800px; height:30px;"></div>
+    <div style="background-color: #101015; color: white">
+      <p>Demo of range selector on dark background, with (left) and without (right) custom range selector gradient color.</p>
+      <div id="darkbg1" style="width:400px; height:300px;display:inline-block;"></div>
+      <div id="darkbg2" style="width:400px; height:300px;display:inline-block;"></div>
+    </div>"
+
     <script type="text/javascript">
       g1 = new Dygraph(
           document.getElementById("noroll"),
@@ -72,6 +78,43 @@
             drawXAxis: false,
             showRangeSelector: true,
             rangeSelectorHeight: 30
+          }
+      );
+      g4 = new Dygraph(
+          document.getElementById("darkbg1"),
+          data_temp,
+          {
+            rollPeriod: 14,
+            showRoller: true,
+            customBars: true,
+            title: 'Nightly Temperatures in NY vs. SF',
+            ylabel: 'Temperature (F)',
+            legend: 'always',
+            labelsDivStyles: { 'textAlign': 'right', 'backgroundColor': '#101015' },
+            showRangeSelector: true,
+            rangeSelectorPlotFillColor: 'MediumSlateBlue',
+            rangeSelectorPlotFillGradientColor: 'rgba(123, 104, 238, 0)',
+            axisLabelColor: 'white',
+            colorValue: 0.9,
+            fillAlpha: 0.4
+          }
+      );
+      g5 = new Dygraph(
+          document.getElementById("darkbg2"),
+          data_temp,
+          {
+            rollPeriod: 14,
+            showRoller: true,
+            customBars: true,
+            title: 'Nightly Temperatures in NY vs. SF',
+            ylabel: 'Temperature (F)',
+            legend: 'always',
+            labelsDivStyles: { 'textAlign': 'right', 'backgroundColor': '#101015' },
+            showRangeSelector: true,
+            rangeSelectorPlotFillColor: 'MediumSlateBlue',
+            axisLabelColor: 'white',
+            colorValue: 0.9,
+            fillAlpha: 0.4
           }
       );
     </script>


### PR DESCRIPTION
If you use dygraphs on a dark background, a filled range selector does not look very good. The fill gradient always fades to a hard-coded 'white' at the top.
An example can be seen in the attached modified tests/range-selector.html

I added an option to specify a custom color to fade to, so the user can choose the page background color or a transparent rgba() color.
