### PR TITLE
Improvement: Prevent unneccessary redraws while updating the visibility state on graphs with many series

### DIFF
--- a/dygraph.js
+++ b/dygraph.js
@@ -3614,6 +3614,22 @@ Dygraph.prototype.setVisibility = function(num, value) {
 };
 
 /**
+ * Changes the visibility of a series by evaluating a modified
+ * array previously obtained from .visibility()
+ *
+ * @param visibilityStatus {Array.<boolean>}  boolean array of visibility status
+ */
+Dygraph.prototype.setVisibilityArray = function (visibilityStatus) {  
+  var x = this.visibility();  
+  if (visibilityStatus.length != x.length) {
+    Dygraph.warn("Array sizes do not match!");
+  } else {
+    x = visibilityStatus;
+    this.predraw_();    
+  }
+};
+
+/**
  * How large of an area will the dygraph render itself in?
  * This is used for testing.
  * @return A {width: w, height: h} object.

--- a/tests/visibility.html
+++ b/tests/visibility.html
@@ -27,6 +27,11 @@
       <input type=checkbox id="2" checked onClick="change(this)">
       <label for="2"> C</label>
     </p>
+    <p><b>Show/Hide Series by Array (works faster on graphs with many series)</b></p>
+    <p>
+      <input type="button" value="show all" onClick="showAll()"/> 
+      <input type="button" value="hide all" onClick="hideAll()"/> 
+    </p>
 
     <p>g.visibility() = <span id="visibility"></span></p>
 
@@ -51,6 +56,27 @@
         g.setVisibility(parseInt(el.id), el.checked);
         setStatus();
       }
+
+      function setAllItems(bValue)
+      {
+        var rgVisibility = g.visibility();
+        rgVisibility.map(function(x, i, ar){
+            ar[i] = bValue;
+        });        
+        g.setVisibilityArray(rgVisibility);        
+        setStatus();
+      }
+
+      function showAll()
+      {
+        setAllItems(true);
+      }
+
+      function hideAll()
+      {
+       setAllItems(false);
+      }
+
     </script>
 
   </body>


### PR DESCRIPTION
- Added the member [.setVisibilityArray], which updates the entire visiblity setting in one call, which works way faster on graphs with > 10 series by preventing unneccessary redraws.
  - Updated testcase
