### PR TITLE
Update dygraph-internal.externs.js to solve compilation conflicts.

### DIFF
--- a/dygraph-internal.externs.js
+++ b/dygraph-internal.externs.js
@@ -16,7 +16,7 @@ G_vmlCanvasManager.initElement = function(canvas) {};
 // For IE
 /**
  * @param {string} type
- * @param {Object} fn
+ * @param {Function} fn
  */
 Element.prototype.detachEvent = function(type, fn) {};
 


### PR DESCRIPTION
detachEvent takes a function not an object (as the param name suggests). This can create compile conflicts.
