### PR TITLE
Fast Fill

### DIFF
--- a/auto_tests/misc/local.html
+++ b/auto_tests/misc/local.html
@@ -63,6 +63,7 @@
   <script type="text/javascript" src="../tests/two_digit_years.js"></script>
   <script type="text/javascript" src="../tests/hidpi.js"></script>
   <script type="text/javascript" src="../tests/smooth_plotter.js"></script>
+  <script type="text/javascript" src="../tests/fast_canvas_proxy.js"></script>
   <script type="text/javascript" src="../tests/update_options.js"></script>
   <script type="text/javascript" src="../tests/update_while_panning.js"></script>
   <script type="text/javascript" src="../tests/utils_test.js"></script>

--- a/auto_tests/tests/fast_canvas_proxy.js
+++ b/auto_tests/tests/fast_canvas_proxy.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Tests for fastCanvasProxy, which drops superfluous segments.
+ *
+ * @author danvdk@gmail.com (Dan Vanderkam)
+ */
+var fastCanvasProxyTestCase = TestCase("fast-canvas-proxy");
+
+fastCanvasProxyTestCase.prototype.setUp = function() {
+};
+
+fastCanvasProxyTestCase.prototype.tearDown = function() {
+};
+
+var fakeCanvasContext = {
+  moveTo: function() {},
+  lineTo: function() {},
+  beginPath: function() {},
+  closePath: function() {},
+  fill: function() {},
+  stroke: function() {}
+}
+
+function extractMoveToAndLineToCalls(proxy) {
+  var calls = proxy.calls__;
+  var out = [];
+  for (var i = 0; i < calls.length; i++) {
+    var c = calls[i];
+    if (c.name == 'moveTo' || c.name == 'lineTo') {
+      out.push([c.name, c.args[0], c.args[1]]);
+    }
+  }
+  return out;
+}
+
+fastCanvasProxyTestCase.prototype.testExtraMoveTosElided = function() {
+  var htx = new Proxy(fakeCanvasContext);
+  var fastProxy = DygraphCanvasRenderer._fastCanvasProxy(htx);
+
+  fastProxy.moveTo(1, 1);
+  fastProxy.lineTo(2, 1);
+  fastProxy.moveTo(2, 1);
+  fastProxy.lineTo(3, 1);
+  fastProxy.moveTo(3, 1);
+  fastProxy.stroke();
+
+  assertEquals([['moveTo', 1, 1],
+                ['lineTo', 2, 1],
+                ['lineTo', 3, 1]], extractMoveToAndLineToCalls(htx));
+};
+
+fastCanvasProxyTestCase.prototype.testConsecutiveMoveTosElided = function() {
+  var htx = new Proxy(fakeCanvasContext);
+  var fastProxy = DygraphCanvasRenderer._fastCanvasProxy(htx);
+
+  fastProxy.moveTo(1, 1);
+  fastProxy.lineTo(2, 1);
+  fastProxy.moveTo(3, 1);
+  fastProxy.moveTo(3.1, 2);
+  fastProxy.moveTo(3.2, 3);
+  fastProxy.stroke();
+
+  assertEquals([['moveTo', 1, 1],
+                ['lineTo', 2, 1],
+                ['moveTo', 3.2, 3]], extractMoveToAndLineToCalls(htx));
+};
+
+fastCanvasProxyTestCase.prototype.testSuperfluousSegmentsElided = function() {
+  var htx = new Proxy(fakeCanvasContext);
+  var fastProxy = DygraphCanvasRenderer._fastCanvasProxy(htx);
+
+  fastProxy.moveTo(0.6, 1);
+  fastProxy.lineTo(0.7, 2);
+  fastProxy.lineTo(0.8, 3);
+  fastProxy.lineTo(0.9, 4);
+  fastProxy.lineTo(1.0, 5);  // max for Math.round(x) == 1
+  fastProxy.lineTo(1.1, 3);
+  fastProxy.lineTo(1.2, 0);  // min for Math.round(x) == 1
+  fastProxy.lineTo(1.3, 1);
+  fastProxy.lineTo(1.4, 2);
+  fastProxy.moveTo(1.4, 2);
+  fastProxy.lineTo(1.5, 2);  // rounding up to 2
+  fastProxy.moveTo(1.5, 2);
+  fastProxy.lineTo(1.6, 3);
+  fastProxy.moveTo(1.6, 3);
+  fastProxy.lineTo(1.7, 30);  // max for Math.round(x) == 2
+  fastProxy.moveTo(1.7, 30);
+  fastProxy.lineTo(1.8, -30);  // min for Math.round(x) == 2
+  fastProxy.moveTo(1.8, -30);
+  fastProxy.lineTo(1.9, 0);
+  fastProxy.moveTo(3, 0);  // dodge the "don't touch the last pixel" rule.
+  fastProxy.stroke();
+
+  assertEquals([['moveTo', 0.6, 1],
+                ['lineTo', 1.0, 5],
+                ['lineTo', 1.2, 0],
+                ['lineTo', 1.7, 30],
+                ['lineTo', 1.8, -30],
+                ['moveTo', 3, 0]], extractMoveToAndLineToCalls(htx));
+};

--- a/auto_tests/tests/step_plot_per_series.js
+++ b/auto_tests/tests/step_plot_per_series.js
@@ -1,6 +1,11 @@
 /**
  * @fileoverview Test cases for the option "stepPlot" especially for the scenario where the option is not set for the whole graph but for single series.
  *
+ * TODO(danvk): delete this test once dpxdt screenshot tests are part of the
+ *     main dygraphs repo. The tests have extremely specific expectations about
+ *     how drawing is performed. It's more realistic to test the resulting
+ *     pixels.
+ *
  * @author julian.eichstaedt@ch.sauter-bc.com (Fr. Sauter AG)
  */
 var StepTestCase = TestCase("step-plot-per-series");
@@ -148,7 +153,7 @@ StepTestCase.prototype.testMixedModeStepAndLineStackedAndFilled = function() {
     CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
     xy1 = xy2;
     xy2 = g.toDomCoords(x2, y2base);
-    CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
+    // CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
     xy1 = xy2;
     xy2 = g.toDomCoords(x1, y1base);
     CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
@@ -172,7 +177,7 @@ StepTestCase.prototype.testMixedModeStepAndLineStackedAndFilled = function() {
     CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
     xy1 = xy2;
     xy2 = g.toDomCoords(x2, y2base);
-    CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
+    // CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
     xy1 = xy2;
     xy2 = g.toDomCoords(x1, y1base);
     CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
@@ -201,7 +206,7 @@ StepTestCase.prototype.testMixedModeStepAndLineStackedAndFilled = function() {
     CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
     xy1 = xy2;
     xy2 = g.toDomCoords(x2, y2base);
-    CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
+    // CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
     xy1 = xy2;
     xy2 = g.toDomCoords(x1, y1base);
     CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
@@ -225,7 +230,7 @@ StepTestCase.prototype.testMixedModeStepAndLineStackedAndFilled = function() {
     CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
     xy1 = xy2;
     xy2 = g.toDomCoords(x2, y2base);
-    CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
+    // CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);
     xy1 = xy2;
     xy2 = g.toDomCoords(x1, y1base);
     CanvasAssertions.assertLineDrawn(htx, xy1, xy2, attrs);

--- a/tests/dense-fill.html
+++ b/tests/dense-fill.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE7; IE=EmulateIE9">
+    <title>dense, filled plots</title>
+    <!--[if IE]>
+    <script type="text/javascript" src="../excanvas.js"></script>
+    <![endif]-->
+    <script type="text/javascript" src="../dygraph-dev.js"></script>
+    <style>
+    .chart {
+      width: 800px;
+      height: 500px;
+    }
+    </style>
+  </head>
+  <body>
+  <p>These charts are substantially sped up by <a href="https://github.com/danvk/dygraphs/pull/462/">down-sampling.</a></p>
+    <div class="chart" data-opts='{"fillGraph":true}'></div>
+
+    <p>step plot, filled</p>
+    <div class="chart" data-opts='{"fillGraph":true,"stepPlot":true}'></div>
+
+    <script>
+      var data = [];
+      for (var i = 0; i < 10000; i++) {
+        data.push([i, Math.sin(i/1000), Math.cos(i/1000)]);
+      }
+
+      var chartDivs = document.querySelectorAll('.chart');
+      for (var i = 0; i < chartDivs.length; i++) {
+        var chartDiv = chartDivs[i];
+        var opts = {labels: ['X', 'sin', 'cos'], animatedZooms: true};
+        var thisOpts = JSON.parse(chartDiv.getAttribute('data-opts'));
+        for (var k in thisOpts) {
+          opts[k] = thisOpts[k];
+        }
+
+        new Dygraph(chartDivs[i], data, opts);
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #346 

There are two main "innovations" here:
1. The chart fill is now drawn in a sane order (see my comment on issue #346 for a chart)
2. I created an optimizing canvas renderer, which drops superfluous points on their way to the canvas.

I took screenshots of `tests/dense-fill.html` both with and without the optimization. There were a few differences with the antialiasing along the edges, but nothing visually distinguishable.

The performance improvement can be dramatic. For a 10,000 point series in a 480x320 chart (i.e. the benchmark), I see a drop from ~700ms/draw → 25ms/draw, which is roughly in line with the performance w/o `fillGraph` set.

The speedup is entirely explained by the number of line segments being sent to the canvas. `tests/dense-fill.html` draws a 10,000 point series on an 800px wide canvas. Before, it issued 40,000 `moveTo` and `lineTo` calls. After, it issues ~1490.
