### PR TITLE
Generate dygraph-combined-dev.js

### DIFF
--- a/generate-combined.sh
+++ b/generate-combined.sh
@@ -2,6 +2,13 @@
 # Generates a single JS file that's easier to include.
 
 GetSources () {
+  # Include dyraph-options-reference only if DEBUG environment variable is set.
+  if [ ! -z "$DEBUG" ]; then
+    maybe_options_reference=dygraph-options-reference.js
+  else
+    maybe_options_reference=''
+  fi
+
   # This list needs to be kept in sync w/ the one in dygraph-dev.js
   # and the one in jsTestDriver.conf. Order matters, except for the plugins.
   for F in \
@@ -18,6 +25,7 @@ GetSources () {
     dygraph-plugin-base.js \
     plugins/*.js \
     dygraph-plugin-install.js \
+    $maybe_options_reference \
     datahandler/datahandler.js \
     datahandler/default.js \
     datahandler/default-fractions.js \
@@ -56,6 +64,11 @@ ls)
   GetSources
   ;;
 cat)
+  Copyright
+  CatSources
+  ;;
+cat-dev)
+  DEBUG=true
   Copyright
   CatSources
   ;;

--- a/push-to-web.sh
+++ b/push-to-web.sh
@@ -10,8 +10,9 @@ fi
 set -x
 site=$1
 
-# Produce dygraph-combined.js.
+# Produce dygraph-combined.js and dygraph-combined-dev.js
 ./generate-combined.sh
+./generate-combined.sh cat-dev > dygraph-combined-dev.js
 
 # Generate documentation.
 ./generate-documentation.py > docs/options.html
@@ -39,6 +40,7 @@ fi
 
 # Revert changes to dygraph-combined.js and docs.
 make clean-combined-test
+rm dygraph-combined-dev.js
 git checkout docs/download.html
 rm docs/options.html
 rm -rf $temp_dir


### PR DESCRIPTION
This is an easy drop-in replacement for `dygraph-combined.js` which gets you the new options validation feature.

This is better than telling people to source `dygraph-dev.js`, which requires them to replicate the entire dygraphs source structure and throws off line numbers in the Chrome debugger.
