### PR TITLE
basic support for multiple y-axes

### DIFF
--- a/dygraph-options-reference.js
+++ b/dygraph-options-reference.js
@@ -667,6 +667,12 @@ Dygraph.OPTIONS_REFERENCE =  // <JSON>
     "type": "string",
     "description" : "Color of the x- and y-axis lines. Accepts any value which the HTML canvas strokeStyle attribute understands, e.g. 'black' or 'rgb(0, 100, 255)'."
   },
+  "position": {
+    "default": "left",
+    "labels": ["Axis display"],
+    "type": "string (left or right)",
+    "description" : "Position of the yAxis."
+  },
   "fillAlpha": {
     "default": "0.15",
     "labels": ["Error Bars", "Data Series Colors"],

--- a/dygraph.js
+++ b/dygraph.js
@@ -780,7 +780,6 @@ Dygraph.prototype.optionsViewForAxis_ = function(axis) {
     var index = -1;
     if(axis !== 'x') {
       index = DygraphOptions.axisToIndex_(axis);
-      console.log(index, axis_opts);
       if(index > 1) {
           if (axis_opts && axis_opts['y2'] && axis_opts['y2'].hasOwnProperty(opt)) {
           return axis_opts['y2'][opt];
@@ -2163,6 +2162,11 @@ Dygraph.prototype.setSelection = function(row, opt_seriesName, opt_locked) {
       // for.  If it is, just use it, otherwise search the array for a point
       // in the proper place.
       var setRow = row - this.getLeftBoundary_(setIdx);
+      if(setRow == -1) {
+        this.lastRow = -1;
+        changed = false;
+        break;
+      }
       if (setRow < points.length && points[setRow].idx == row) {
         var point = points[setRow];
         if (point.yval !== null) this.selPoints_.push(point);

--- a/dygraph.js
+++ b/dygraph.js
@@ -777,16 +777,25 @@ Dygraph.prototype.optionsViewForAxis_ = function(axis) {
     if (axis_opts && axis_opts[axis] && axis_opts[axis].hasOwnProperty(opt)) {
       return axis_opts[axis][opt];
     }
+    var index = -1;
+    if(axis !== 'x') {
+      index = DygraphOptions.axisToIndex_(axis);
+      console.log(index, axis_opts);
+      if(index > 1) {
+          if (axis_opts && axis_opts['y2'] && axis_opts['y2'].hasOwnProperty(opt)) {
+          return axis_opts['y2'][opt];
+        }
+      }
+    }
     // check old-style axis options
     // TODO(danvk): add a deprecation warning if either of these match.
     if(axis !== 'x') {
-      var index = DygraphOptions.axisToIndex_(axis);
       if (self.axes_[index].hasOwnProperty(opt)) {
         return self.axes_[index][opt];
       } else {
         if(index > 1) {
-          if (self.axes_[1].hasOwnProperty(opt)) {
-            return self.axes_[1][opt];
+          if (self.axes_[0].hasOwnProperty(opt)) {
+            return self.axes_[0][opt];
           }
         }
       }
@@ -2771,7 +2780,7 @@ Dygraph.prototype.computeYAxes_ = function() {
 
   for (axis = 0; axis < this.axes_.length; axis++) {
     if (axis === 0) {
-      opts = this.optionsViewForAxis_('y' + (axis ? '2' : ''));
+      opts = this.optionsViewForAxis_('y' + (axis ? (axis+1) : ''));
       v = opts("valueRange");
       if (v) this.axes_[axis].valueRange = v;
     } else {  // To keep old behavior
@@ -2946,7 +2955,7 @@ Dygraph.prototype.computeYAxisRanges_ = function(extremes) {
     
     if (independentTicks) {
       axis.independentTicks = independentTicks;
-      var opts = this.optionsViewForAxis_('y' + (i ? '2' : ''));
+      var opts = this.optionsViewForAxis_('y' + (i ? (i+1) : ''));
       var ticker = opts('ticker');
       axis.ticks = ticker(axis.computedValueRange[0],
               axis.computedValueRange[1],
@@ -2967,7 +2976,7 @@ Dygraph.prototype.computeYAxisRanges_ = function(extremes) {
     var axis = this.axes_[i];
     
     if (!axis.independentTicks) {
-      var opts = this.optionsViewForAxis_('y' + (i ? '2' : ''));
+      var opts = this.optionsViewForAxis_('y' + (i ? (i+1) : ''));
       var ticker = opts('ticker');
       var p_ticks = p_axis.ticks;
       var p_scale = p_axis.computedValueRange[1] - p_axis.computedValueRange[0];

--- a/plugins/legend.js
+++ b/plugins/legend.js
@@ -277,7 +277,7 @@ legend.generateLegendHTML = function(g, x, sel_points, oneEmWidth, row) {
     var series = g.getPropertiesForSeries(pt.name);
     var yOptView = yOptViews[series.axis - 1];
     var fmtFunc = yOptView('valueFormatter');
-    var yval = fmtFunc.call(g, pt.yval, yOptView, pt.name, g, row, labels.indexOf(pt.name));
+    var yval = fmtFunc? fmtFunc.call(g, pt.yval, yOptView, pt.name, g, row, labels.indexOf(pt.name)) : pt.yval;
 
     var cls = (pt.name == highlightSeries) ? " class='highlight'" : "";
 


### PR DESCRIPTION
Just opening this pull request for discussions.

I started to implement support for multiple y-axes in the axes and labels plugin. It needed some changes in the layout, too. I introduced a "position" setting for axes to select if the axis is shown at the left or right. I use the naming "y3", "y4", .. for the additional axes.

1) The current naming scheme makes it difficult to handle the settings, maybe it would be better to change the axes configuration to an array, but this would break compatibility to the previous versions. What do you think about it?

2) I would like to implement dynamic tick-label widths, so that the width of the labels get adapted to the text length of the containing text at zoom. So the reserved space at left and right could change dynamically. How should this be handled best? My current proposal would be to emit an layout event, if the length of the ticks changes significantly.

There are some tests failing, I will fix them if we agree in the changes.