### PR TITLE
legend: follow positioning fixes

### DIFF
--- a/plugins/legend.js
+++ b/plugins/legend.js
@@ -141,13 +141,13 @@ legend.prototype.select = function(e) {
     // within the plotter_ area
     // offset 20 px to the right and down from the first selection point
     // 20 px is guess based on mouse cursor size
-    var leftLegend = points[0].x * area.w + 20;
-    var topLegend  = points[0].y * area.h - 20;
+    var leftLegend = points[0].x * area.w + 50;
+    var topLegend  = points[0].y * area.h - 50;
 
-    // if legend floats to end of the window area, it flips to the other
+    // if legend floats to end of the chart area, it flips to the other
     // side of the selection point
-    if ((leftLegend + labelsDivWidth + 1) > (window.scrollX + window.innerWidth)) {
-      leftLegend = leftLegend - 2 * 20 - labelsDivWidth - (yAxisLabelWidth - area.x);
+    if ((leftLegend + labelsDivWidth + 1) > area.w) {
+      leftLegend = leftLegend - 2 * 50 - labelsDivWidth - (yAxisLabelWidth - area.x);
     }
 
     e.dygraph.graphDiv.appendChild(this.legend_div_);

--- a/plugins/legend.js
+++ b/plugins/legend.js
@@ -139,8 +139,8 @@ legend.prototype.select = function(e) {
     var yAxisLabelWidth = e.dygraph.getOptionForAxis('axisLabelWidth', 'y');
     // determine floating [left, top] coordinates of the legend div
     // within the plotter_ area
-    // offset 20 px to the right and down from the first selection point
-    // 20 px is guess based on mouse cursor size
+    // offset 50 px to the right and down from the first selection point
+    // 50 px is guess based on mouse cursor size
     var leftLegend = points[0].x * area.w + 50;
     var topLegend  = points[0].y * area.h - 50;
 


### PR DESCRIPTION
I've run into issue with legend position when it was clipped by overflow: hidden (using fixed width modal to show the chart), so I think it might make more sense to switch position when it would go outside chart area.

Also proposing 20->50px to show more points around currently highlighted one. When you move your mouse quickly, it might jump inside legend area which then stops following and stays put - especially when you have wider gaps in your data (even as you move your mouse over the gap, legend stays in one place until you reach next point).