### PR TITLE
delay synchronizing until all the dygraphs are ready.

### DIFF
--- a/extras/synchronizer.js
+++ b/extras/synchronizer.js
@@ -100,16 +100,24 @@ Dygraph.synchronize = function(/* dygraphs..., opts */) {
     throw 'Invalid invocation of Dygraph.synchronize(). ' +
           'Need two or more dygraphs to synchronize.';
   }
+  
+  var readycount = dygraphs.length;
+  for (var i = 0; i < dygraphs.length; i++) {
+    var g = dygraphs[i];
+    g.ready( function() {
+      if (--readycount == 0) {
+        // Listen for draw, highlight, unhighlight callbacks.
+        if (opts.zoom) {
+          attachZoomHandlers(dygraphs, opts, prevCallbacks);
+        }
 
-  // Listen for draw, highlight, unhighlight callbacks.
-  if (opts.zoom) {
-    attachZoomHandlers(dygraphs, opts, prevCallbacks);
+        if (opts.selection) {
+          attachSelectionHandlers(dygraphs, prevCallbacks);
+        }
+      }
+    });
   }
-
-  if (opts.selection) {
-    attachSelectionHandlers(dygraphs, prevCallbacks);
-  }
-
+ 
   return {
     detach: function() {
       for (var i = 0; i < dygraphs.length; i++) {


### PR DESCRIPTION
Urgh. This is a start, but it creates a new bug: cross-contamination between graphs. See, for example, http://rths.us/viz.cgi?from=2015-02-05&to=2015-02-19&state=serieses&siteid=4&config=config.json&seriesid-2600=15&seriesid-2604=16&seriesid-2605=17&seriesid-2125=18&seriesid-2602=33&seriesid-2603=34&seriesid-2606=35&seriesid-2607=36&seriesid-2124=37&seriesid-2126=38

The graphs all have the same Y scale, even though they have different data. So the data is visible on some graphs, but not visible on other graphs. Also, if I move the cursor within the first graph, the second graph moves jerkily if at all. Same with the third. But if I put my cursor within the second graph, the first and third graphs move smoothly.

Also, I don't see any good way to test this, because it fixes a bug when a file is loaded over the network.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/danvk/dygraphs/552)
<!-- Reviewable:end -->
