### PR TITLE
update setVisibility to be able to set the visibility of multiple series at once

### DIFF
--- a/auto_tests/misc/local.html
+++ b/auto_tests/misc/local.html
@@ -66,6 +66,7 @@
   <script type="text/javascript" src="../tests/update_options.js"></script>
   <script type="text/javascript" src="../tests/update_while_panning.js"></script>
   <script type="text/javascript" src="../tests/utils_test.js"></script>
+  <script type="text/javascript" src="../tests/visibility.js"></script>
 
 <style type="text/css">
   .pass .outcome {

--- a/auto_tests/tests/visibility.js
+++ b/auto_tests/tests/visibility.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Tests for the setVisibility function.
+ * @author sergeyslepian@gmail.com
+ */
+
+var VisibilityTestCase = TestCase("visibility");
+
+VisibilityTestCase.prototype.setUp = function() {
+  document.body.innerHTML = "<div id='graph'></div>";
+};
+
+VisibilityTestCase.prototype.tearDown = function() {
+};
+
+/**
+ * Does a bunch of the shared busywork of setting up a graph and changing its visibility.
+ * @param {boolean} startingVisibility The starting visibility of all series on the graph
+ * @param {*[]} setVisibilityArgs An array of arguments to be passed directly to setVisibility()
+ * @returns {string} The output of Util.getLegend() called after the visibility is set
+ */
+VisibilityTestCase.prototype.getVisibleSeries = function(startingVisibility, setVisibilityArgs) {
+  var opts = {
+    width: 480,
+    height: 320,
+    labels: ['x', 'A', 'B', 'C', 'D', 'E'],
+    legend: 'always',
+    visibility: []
+  };
+
+  // set the starting visibility
+  var numSeries = opts.labels.length - 1;
+  for(var i = 0; i < numSeries; i++) {
+    opts.visibility[i] = startingVisibility;
+  }
+
+  var data = [];
+  for (var j = 0; j < 10; j++) {
+    data.push([j, 1, 2, 3, 4, 5]);
+  }
+
+  var graph = document.getElementById("graph");
+  var g = new Dygraph(graph, data, opts);
+
+  g.setVisibility.apply(g, setVisibilityArgs);
+
+  return Util.getLegend();
+};
+
+VisibilityTestCase.prototype.testDefaultCases = function() {
+  assertEquals(' A  B  C  D  E', this.getVisibleSeries(true, [[], true]));
+  assertEquals('', this.getVisibleSeries(false, [[], true]));
+};
+
+VisibilityTestCase.prototype.testSingleSeriesHide = function() {
+  assertEquals(' A  C  D  E', this.getVisibleSeries(true, [1, false]));
+};
+
+VisibilityTestCase.prototype.testSingleSeriesShow = function() {
+  assertEquals(' E', this.getVisibleSeries(false, [4, true]));
+};
+
+VisibilityTestCase.prototype.testMultiSeriesHide = function() {
+  assertEquals(' A  E', this.getVisibleSeries(true, [[1,2,3], false]));
+};
+
+VisibilityTestCase.prototype.testMultiSeriesShow = function() {
+  assertEquals(' B  D', this.getVisibleSeries(false, [[1,3], true]));
+};

--- a/dygraph.js
+++ b/dygraph.js
@@ -3602,19 +3602,25 @@ Dygraph.prototype.visibility = function() {
 };
 
 /**
- * Changes the visiblity of a series.
+ * Changes the visibility of one or more series.
  *
- * @param {number} num the series index
+ * @param {number|number[]} num the series index or an array of series indices
  * @param {boolean} value true or false, identifying the visibility.
  */
 Dygraph.prototype.setVisibility = function(num, value) {
   var x = this.visibility();
-  if (num < 0 || num >= x.length) {
-    console.warn("invalid series number in setVisibility: " + num);
-  } else {
-    x[num] = value;
-    this.predraw_();
+
+  if (num.constructor !== Array) num = [num];
+
+  for (var i = 0; i < num.length; i++) {
+    if (num[i] < 0 || num[i] >= x.length) {
+      console.warn("invalid series number in setVisibility: " + num[i]);
+    } else {
+      x[num[i]] = value;
+    }
   }
+
+  this.predraw_();
 };
 
 /**


### PR DESCRIPTION
Currently, each visibility change triggers a redraw, which causes functionality like hiding/showing all series (or applying a filter) to be very slow. This change allows setVisibility() to accept an array instead of a single numbers so that the redraw only happens after the visibility of multiple series has been updated.

This replaces https://github.com/danvk/dygraphs/pull/559