### PR TITLE
Update reference to drawGrid option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
+sudo: false  # use container-based architecture
 
 script: "make travis"

--- a/tests/plotters.html
+++ b/tests/plotters.html
@@ -107,8 +107,12 @@
                 includeZero: true,
                 dateWindow: [ Date.parse("2012/07/20"), Date.parse("2012/07/26") ],
                 animatedZooms: true,
-                drawXGrid: false,
-                plotter: barChartPlotter
+                plotter: barChartPlotter,
+                axes: {
+                  x: {
+                    drawGrid: false
+                  }
+                }
               }
           );
 


### PR DESCRIPTION
`tests/plotters.html` was broken before (no charts rendered).

Also updates us to use Travis-CI's [container-based architecture][1], which should make builds start faster.

[1]: http://docs.travis-ci.com/user/workers/container-based-infrastructure/