### PR TITLE
Remove all test warnings

### DIFF
--- a/auto_tests/tests/Util.js
+++ b/auto_tests/tests/Util.js
@@ -147,3 +147,24 @@ Util.overrideXMLHttpRequest = function(data) {
 Util.formatDate = function(dateMillis) {
   return Dygraph.dateString_(dateMillis).slice(0, 10);  // 10 == "YYYY/MM/DD".length
 };
+
+/**
+ * Capture console.{log,warn,error} statements into obj.
+ * obj will look like {log:[], warn:[], error:[]}
+ * This returns a function which will restore the original console.
+ */
+Util.captureConsole = function(obj) {
+  obj.log = [];
+  obj.warn = [];
+  obj.error = [];
+  var orig = [console.log, console.warn, console.error];
+  console.log = function(text) { obj.log.push(text); };
+  console.warn = function(text) { obj.warn.push(text); };
+  console.error = function(text) { obj.error.push(text); };
+
+  return function() {
+    console.log = orig[0];
+    console.warn = orig[1];
+    console.error = orig[2];
+  };
+};

--- a/auto_tests/tests/axis_labels-deprecated.js
+++ b/auto_tests/tests/axis_labels-deprecated.js
@@ -16,7 +16,8 @@ afterEach(function() {
 it('testDeprecatedDeprecatedXAxisTimeLabelFormatter', function() {
   var opts = {
     width: 480,
-    height: 320
+    height: 320,
+    labels: ['X', 'Y1']
   };
   var data = [[5.0,0],[5.1,1],[5.2,2],[5.3,3],[5.4,4],[5.5,5],[5.6,6],[5.7,7],[5.8,8],[5.9,9]];
   var graph = document.getElementById("graph");

--- a/auto_tests/tests/axis_labels.js
+++ b/auto_tests/tests/axis_labels.js
@@ -125,7 +125,8 @@ it('testSmallRangeAwayFromZero', function() {
 it('testXAxisTimeLabelFormatter', function() {
   var opts = {
     width: 480,
-    height: 320
+    height: 320,
+    labels: ['X', 'Y1']
   };
   var data = [[5.0,0],[5.1,1],[5.2,2],[5.3,3],[5.4,4],[5.5,5],[5.6,6],[5.7,7],[5.8,8],[5.9,9]];
   var graph = document.getElementById("graph");
@@ -672,7 +673,11 @@ it('testSmallLabelKMG2', function() {
  * Verify that log scale axis range is properly specified.
  */
 it('testLogScale', function() {
-  var g = new Dygraph("graph", [[0, 5], [1, 1000]], { logscale : true });
+  var g = new Dygraph("graph",
+                      [[0, 5], [1, 1000]], {
+                        logscale: true,
+                        labels: ['X', 'Y']
+                      });
   var nonEmptyLabels = Util.getYLabels().filter(function(x) { return x.length > 0; });
   assert.deepEqual(["5","10","20","50","100","200","500","1000"], nonEmptyLabels);
  
@@ -684,7 +689,11 @@ it('testLogScale', function() {
  * Verify that include zero range is properly specified.
  */
 it('testIncludeZero', function() {
-  var g = new Dygraph("graph", [[0, 500], [1, 1000]], { includeZero : true });
+  var g = new Dygraph("graph",
+                      [[0, 500], [1, 1000]], {
+                        includeZero: true,
+                        labels: ['X', 'Y1']
+                      });
   assert.deepEqual(['0','200','400','600','800','1000'], Util.getYLabels());
  
   g.updateOptions({ includeZero : false });
@@ -701,18 +710,18 @@ it('testAxisLabelFontSize', function() {
   var assertFontSize = function(selector, expected) {
     Util.assertStyleOfChildren(selector, "font-size", expected);
   }
-  
-  assertFontSize(document.querySelectorAll(".dygraph-axis-label-x"), "14px");
-  assertFontSize(document.querySelectorAll(".dygraph-axis-label-y") , "14px");
 
-  g.updateOptions({ axisLabelFontSize : 8});
+  assertFontSize(document.querySelectorAll(".dygraph-axis-label-x"), "14px");
+  assertFontSize(document.querySelectorAll(".dygraph-axis-label-y"), "14px");
+
+  g.updateOptions({axisLabelFontSize : 8});
   assertFontSize(document.querySelectorAll(".dygraph-axis-label-x"), "8px"); 
   assertFontSize(document.querySelectorAll(".dygraph-axis-label-y"), "8px"); 
 
   g.updateOptions({
     axisLabelFontSize : null,
-    axes : { 
-      x : { axisLabelFontSize : 5 },
+    axes: { 
+      x: { axisLabelFontSize : 5 },
     }   
   }); 
 
@@ -720,8 +729,8 @@ it('testAxisLabelFontSize', function() {
   assertFontSize(document.querySelectorAll(".dygraph-axis-label-y"), "14px");
 
   g.updateOptions({
-    axes : { 
-      y : { axisLabelFontSize : 20 },
+    axes: { 
+      y: { axisLabelFontSize : 20 },
     }   
   }); 
 
@@ -729,11 +738,11 @@ it('testAxisLabelFontSize', function() {
   assertFontSize(document.querySelectorAll(".dygraph-axis-label-y"), "20px"); 
 
   g.updateOptions({
-    series : { 
-      Y2 : { axis : "y2" } // copy y2 series to y2 axis.
+    series: { 
+      Y2: { axis : "y2" } // copy y2 series to y2 axis.
     },  
-    axes : { 
-      y2 : { axisLabelFontSize : 12 },
+    axes: { 
+      y2: { axisLabelFontSize : 12 },
     }   
   }); 
 

--- a/auto_tests/tests/callback.js
+++ b/auto_tests/tests/callback.js
@@ -696,9 +696,9 @@ it('testDrawHighlightPointCallback_idx', function() {
   };
   var testdata = [[1, 2], [2, 3], [3, NaN], [4, 2], [5, NaN], [6, 3]];
   var graph = document.getElementById("graph");
-  var g = new Dygraph(graph, testdata,
-      {
-          drawHighlightPointCallback : drawHighlightPointCallback
+  var g = new Dygraph(graph, testdata, {
+        drawHighlightPointCallback: drawHighlightPointCallback,
+        labels: ['X', 'Y']
       });
 
   assert.isNull(idxToCheck);

--- a/auto_tests/tests/custom_bars.js
+++ b/auto_tests/tests/custom_bars.js
@@ -99,19 +99,20 @@ it('testCustomBarsAtTop', function() {
         width: 500, height: 350,
         customBars: true,
         errorBars: true,
-        axes : {
-          x : {
+        axes: {
+          x: {
             drawGrid: false,
             drawAxis: false,
           },
-          y : {
+          y: {
             drawGrid: false,
             drawAxis: false,
           }
         },
         valueRange: [0, 120],
         fillAlpha: 0.15,
-        colors: [ '#00FF00' ]
+        colors: ['#00FF00'],
+        labels: ['X', 'Y']
       });
 
   var sampler = new PixelSampler(g);
@@ -142,7 +143,8 @@ it('testCustomBarsLogScale', function() {
         },
         fillAlpha: 1.0,
         logscale: true,
-        colors: [ '#00FF00' ]
+        colors: ['#00FF00'],
+        labels: ['X', 'Y']
       });
 
   // The following assertions describe the sides of the custom bars, which are
@@ -180,8 +182,9 @@ it('testCustomBarsWithNegativeValuesInLogScale', function() {
       ],
       {
         drawPoints: true,
-        drawPointCallback : drawPointCallback,
-        customBars: true
+        drawPointCallback: drawPointCallback,
+        customBars: true,
+        labels: ['X', 'Y']
       });
 
   // Normally all three points would be drawn.

--- a/auto_tests/tests/error_bars.js
+++ b/auto_tests/tests/error_bars.js
@@ -36,7 +36,8 @@ it('testErrorBarsDrawn', function() {
       }
     },
     customBars: true,
-    errorBars: true
+    errorBars: true,
+    labels: ['X', 'Y']
   };
   var data = [
                [1, [10,  10, 100]],

--- a/auto_tests/tests/formats.js
+++ b/auto_tests/tests/formats.js
@@ -24,6 +24,7 @@ var dataArray =
   [1,0],
   [2,1],
   [3,0]];
+var BASE_OPTS = {labels: ['X', 'Y']};
 
 it('testCsv', function() {
   var data = dataString;
@@ -35,7 +36,7 @@ it('testCsv', function() {
 it('testArray', function() {
   var data = dataArray;
   var graph = document.getElementById("graph");
-  var g = new Dygraph(graph, data, {});
+  var g = new Dygraph(graph, data, BASE_OPTS);
   assertData(g);
 });
 
@@ -54,7 +55,7 @@ it('testFunctionDefinesArray', function() {
   var data = function() { return array; }
 
   var graph = document.getElementById("graph");
-  var g = new Dygraph(graph, data, {});
+  var g = new Dygraph(graph, data, BASE_OPTS);
   assertData(g);
 });
 

--- a/auto_tests/tests/formats.js
+++ b/auto_tests/tests/formats.js
@@ -41,13 +41,11 @@ it('testArray', function() {
 });
 
 it('testFunctionReturnsCsv', function() {
-  var string = dataString;
-  var data = function() { return string; };
+  var data = function() { return dataString; };
 
   var graph = document.getElementById("graph");
   var g = new Dygraph(graph, data, {});
-  // assertData(g);
-  console.log("x");
+  assertData(g);
 });
 
 it('testFunctionDefinesArray', function() {

--- a/auto_tests/tests/interaction_model.js
+++ b/auto_tests/tests/interaction_model.js
@@ -19,15 +19,16 @@ var data1 = "X,Y\n" +
     "23,0\n";
 
 var data2 =
-    [[1, 10],
-    [2, 20],
-    [3, 30],
-    [4, 40],
-    [5, 120],
-    [6, 50],
-    [7, 70],
-    [8, 90],
-    [9, 50]];
+    "X,Y\n" +
+    "1,10\n" +
+    "2,20\n" +
+    "3,30\n" +
+    "4,40\n" +
+    "5,120\n" +
+    "6,50\n" +
+    "7,70\n" +
+    "8,90\n" +
+    "9,50\n";
 
 function getXLabels() {
   var x_labels = document.getElementsByClassName("dygraph-axis-label-x");
@@ -169,15 +170,16 @@ it('testClickCallbackIsCalledWithNonInteractiveModel', function() {
  * A sanity test to ensure pointClickCallback is called.
  */
 it('testPointClickCallback', function() {
-  var clicked;
-  var g = new Dygraph(document.getElementById("graph"), data2, {
-    pointClickCallback : function(event, point) {
+  var clicked = null;
+  var g = new Dygraph('graph', data2, {
+    pointClickCallback: function(event, point) {
       clicked = point;
     }
   });
 
   clickAt(g, 4, 40);
 
+  assert.isNotNull(clicked);
   assert.equal(4, clicked.xval);
   assert.equal(40, clicked.yval);
 });

--- a/auto_tests/tests/missing_points.js
+++ b/auto_tests/tests/missing_points.js
@@ -61,7 +61,7 @@ it('testSeparatedPointsDontDraw_expanded', function() {
        [2, null],
        [3, 13],
        [4, 14]],
-      { colors: ['blue']});
+      { colors: ['blue'], labels: ['X', 'Y']});
   var htx = g.hidden_ctx_;
 
   assert.equal(2, CanvasAssertions.numLinesDrawn(htx, '#0000ff'));
@@ -80,7 +80,11 @@ it('testSeparatedPointsDontDraw_expanded_connected', function() {
        [2, null],
        [3, 13],
        [4, 14]],
-      { colors: ['blue'], connectSeparatedPoints: true});
+      {
+        colors: ['blue'],
+        connectSeparatedPoints: true,
+        labels: ['X', 'Y']
+      });
   var htx = g.hidden_ctx_;
   var num_lines = 0;
 
@@ -107,7 +111,8 @@ it('testConnectSeparatedPoints', function() {
     {
       connectSeparatedPoints: true,
       drawPoints: true,
-      colors: ['red', 'blue']
+      colors: ['red', 'blue'],
+      labels: ['X', 'Y1', 'Y2']
     }
   );
 
@@ -182,7 +187,8 @@ it('testErrorBarsWithMissingPoints', function() {
     data,
     {
       errorBars: true,
-      colors: ['red']
+      colors: ['red'],
+      labels: ['X', 'Y']
     }
   );
 
@@ -216,7 +222,8 @@ it('testErrorBarsWithMissingPointsConnected', function() {
       connectSeparatedPoints: true,
       drawPoints: true,
       errorBars: true,
-      colors: ['red']
+      colors: ['red'],
+      labels: ['X', 'Y']
     }
   );
 
@@ -251,7 +258,8 @@ it('testCustomBarsWithMissingPoints', function() {
     data,
     {
       customBars: true,
-      colors: ['red']
+      colors: ['red'],
+      labels: ['X', 'Y']
     }
   );
 
@@ -292,7 +300,8 @@ it('testCustomBarsWithMissingPointsConnected', function() {
       connectSeparatedPoints: true,
       drawPoints: true,
       customBars: true,
-      colors: ['red']
+      colors: ['red'],
+      labels: ['X', 'Y']
     }
   );
 
@@ -323,7 +332,8 @@ it('testLeftBoundaryWithMisingPoints', function() {
     {
       connectSeparatedPoints: true,
       drawPoints: true,
-      colors: ['red','blue']
+      colors: ['red','blue'],
+      labels: ['X', 'Y1', 'Y2']
     }
   );
   g.updateOptions({ dateWindow : [ 2.5, 4.5 ] });

--- a/auto_tests/tests/missing_points.js
+++ b/auto_tests/tests/missing_points.js
@@ -46,7 +46,10 @@ it('testSeparatedPointsDontDraw', function() {
       [[1, 10, 11],
        [2, 11, null],
        [3, 12, 13]],
-      { colors: ['red', 'blue']});
+      {
+        colors: ['red', 'blue'],
+        labels: ['X', 'Y1', 'Y2']
+      });
   var htx = g.hidden_ctx_;
   assert.equal(2, CanvasAssertions.numLinesDrawn(htx, '#ff0000'));
   assert.equal(0, CanvasAssertions.numLinesDrawn(htx, '#0000ff'));

--- a/auto_tests/tests/pathological_cases.js
+++ b/auto_tests/tests/pathological_cases.js
@@ -6,11 +6,15 @@
  */
 describe("pathological-cases", function() {
 
+var restoreConsole;
+var logs = {};
 beforeEach(function() {
   document.body.innerHTML = "<div id='graph'></div>";
+  restoreConsole = Util.captureConsole(logs);
 });
 
 afterEach(function() {
+  restoreConsole();
 });
 
 it('testZeroPoint', function() {
@@ -111,6 +115,16 @@ it('testCombinations', function() {
         opts.labels = ['X', 'A', 'B', 'C'].slice(0, cols);
 
         var g = new Dygraph(gdiv, data, opts);
+
+        if (dataName == 'empty') {
+          assert.deepEqual(logs, {
+            log: [], warn: [],
+            error: ["Can't plot empty data set"]
+          });
+          logs.error = [];  // reset
+        } else {
+          assert.deepEqual(logs, {log: [], warn: [], error: []});
+        }
       }
     }
   }

--- a/auto_tests/tests/range_selector.js
+++ b/auto_tests/tests/range_selector.js
@@ -6,11 +6,15 @@
  */
 describe("range-selector", function() {
 
+var restoreConsole;
+var logs = {};
 beforeEach(function() {
   document.body.innerHTML = "<div id='graph'></div>";
+  restoreConsole = Util.captureConsole(logs);
 });
 
 afterEach(function() {
+  restoreConsole();
 });
 
 it('testRangeSelector', function() {
@@ -216,6 +220,10 @@ it('testRangeSelectorWithAnimatedZoomsOption', function() {
   var g = new Dygraph(graph, data, opts);
   assertGraphExistence(g, graph);
   assert.isFalse(g.getOption('animatedZooms'));
+  assert.deepEqual(logs, {
+    log: [], error: [],
+    warn: ["Animated zooms and range selector are not compatible; disabling animatedZooms."]
+  });
 });
 
 it('testRangeSelectorWithAnimatedZoomsOption2', function() {
@@ -241,6 +249,10 @@ it('testRangeSelectorWithAnimatedZoomsOption2', function() {
   g.updateOptions({showRangeSelector: true});
   assertGraphExistence(g, graph);
   assert.isFalse(g.getOption('animatedZooms'));
+  assert.deepEqual(logs, {
+    log: [], error: [],
+    warn: ["Animated zooms and range selector are not compatible; disabling animatedZooms."]
+  });
 });
 
 it('testRangeSelectorInteraction', function() {

--- a/auto_tests/tests/range_tests.js
+++ b/auto_tests/tests/range_tests.js
@@ -50,8 +50,9 @@ var createGraph = function(opts, data, expectRangeX, expectRangeY) {
   if (data === undefined) data = ZERO_TO_FIFTY_STEPS;
   if (expectRangeX === undefined) expectRangeX = [10, 20];
   if (expectRangeY === undefined) expectRangeY = [0, 55];
-  var graph = document.getElementById("graph");
-  var g = new Dygraph(graph, data, opts);
+  if (!opts) opts = {};
+  opts['labels'] = ['X', 'Y'];
+  var g = new Dygraph('graph', data, opts);
 
   assertDeepCloseTo(expectRangeX, g.xAxisRange(), 0.01);
   assertDeepCloseTo(expectRangeY, g.yAxisRange(0), 0.01);
@@ -172,7 +173,10 @@ it('testRestoreOriginalRanges_viaUpdateOptions', function() {
  * Verify that log scale axis range is properly specified.
  */
 it('testLogScaleExcludesZero', function() {
-  var g = new Dygraph("graph", FIVE_TO_ONE_THOUSAND, { logscale : true });
+  var g = new Dygraph("graph", FIVE_TO_ONE_THOUSAND, {
+    logscale: true,
+    labels: ['X', 'Y']
+  });
   assert.deepEqual([10, 1099], g.yAxisRange(0));
  
   g.updateOptions({ logscale : false });
@@ -183,7 +187,10 @@ it('testLogScaleExcludesZero', function() {
  * Verify that includeZero range is properly specified.
  */
 it('testIncludeZeroIncludesZero', function() {
-  var g = new Dygraph("graph", [[0, 500], [500, 1000]], { includeZero : true });
+  var g = new Dygraph("graph", [[0, 500], [500, 1000]], {
+    includeZero: true,
+    labels: ['X', 'Y']
+  });
   assert.deepEqual([0, 1100], g.yAxisRange(0));
  
   g.updateOptions({ includeZero : false });
@@ -233,7 +240,10 @@ it('testIncludeZeroPerAxis', function() {
  * Verify that very large Y ranges don't break things.
  */ 
 it('testHugeRange', function() {
-  var g = new Dygraph("graph", [[0, -1e120], [1, 1e230]], { includeZero : true });
+  var g = new Dygraph("graph", [[0, -1e120], [1, 1e230]], {
+    includeZero: true,
+    labels: ['X', 'Y']
+  });
   assert.closeTo(1, -1e229 / g.yAxisRange(0)[0], 0.001);
   assert.closeTo(1, 1.1e230 / g.yAxisRange(0)[1], 0.001);
 });

--- a/auto_tests/tests/rolling_average.js
+++ b/auto_tests/tests/rolling_average.js
@@ -85,7 +85,7 @@ it('testRollBoxDoesntDisapper', function() {
 it('testRollShortFractions', function() {
   var opts = {
     customBars: true,
-    labels: ['x', 'A']
+    labels: ['x', 'A', 'B']
   };
   var data1 = [ [1, 10, [1, 20]] ];
   var data2 = [ [1, 10, [1, 20]],

--- a/auto_tests/tests/sanity.js
+++ b/auto_tests/tests/sanity.js
@@ -24,8 +24,8 @@
  *
  * @author konigsberg@google.com (Robert Konigsberg)
  */
-var DEAD_SIMPLE_DATA = [[ 10, 2100 ]];
-var ZERO_TO_FIFTY = [[ 10, 0 ] , [ 20, 50 ]];
+var DEAD_SIMPLE_DATA = 'X,Y\n10,2100';
+var ZERO_TO_FIFTY = 'X,Y\n10,0\n20,50';
 
 describe("dygraphs-sanity", function() {
 

--- a/auto_tests/tests/sanity.js
+++ b/auto_tests/tests/sanity.js
@@ -24,10 +24,11 @@
  *
  * @author konigsberg@google.com (Robert Konigsberg)
  */
-var DEAD_SIMPLE_DATA = 'X,Y\n10,2100';
-var ZERO_TO_FIFTY = 'X,Y\n10,0\n20,50';
 
 describe("dygraphs-sanity", function() {
+
+var DEAD_SIMPLE_DATA = 'X,Y\n10,2100';
+var ZERO_TO_FIFTY = 'X,Y\n10,0\n20,50';
 
 beforeEach(function() {
   document.body.innerHTML = "<div id='graph'></div>";

--- a/auto_tests/tests/selection.js
+++ b/auto_tests/tests/selection.js
@@ -73,9 +73,9 @@ it('testSetGetSelectionMissingPoints', function() {
   var graph = document.getElementById("graph");
   var g = new Dygraph(graph,
     "X,A,B,C\n" +
-    "1,1,null,null\n" +
-    "2,null,2,null\n" +
-    "3,null,null,3\n",
+    "1,1,,\n" +
+    "2,,2,\n" +
+    "3,,,3\n",
     {
       dataHandler: dataHandler
     }

--- a/auto_tests/tests/simple_drawing.js
+++ b/auto_tests/tests/simple_drawing.js
@@ -23,9 +23,10 @@
  *
  * @author konigsberg@google.com (Robert Konigsberg)
  */
-var ZERO_TO_FIFTY = [[ 10, 0 ] , [ 20, 50 ]];
 
 describe("simple-drawing", function() {
+
+var ZERO_TO_FIFTY = 'X,Y\n10,0\n20,50';
 
 var _origFunc = Dygraph.getContext;
 beforeEach(function() {
@@ -41,17 +42,18 @@ afterEach(function() {
 
 it('testDrawSimpleRangePlusOne', function() {
   var opts = {
-    axes : {
-      x : {
+    axes: {
+      x: {
         drawGrid: false,
-        drawAxis: false,
+        drawAxis: false
       },
-      y : {
+      y: {
         drawGrid: false,
-        drawAxis: false,
+        drawAxis: false
       }
     },
-    valueRange: [0,51] }
+    valueRange: [0,51]
+  };
 
   var graph = document.getElementById("graph");
   var g = new Dygraph(graph, ZERO_TO_FIFTY, opts);
@@ -121,7 +123,8 @@ it('testDrawSimpleDash', function() {
     series: {
       'Y1': {strokePattern: [25, 7, 7, 7]},
     },
-    colors: ['#ff0000']
+    colors: ['#ff0000'],
+    labels: ['X', 'Y']
   };
 
   var graph = document.getElementById("graph");
@@ -143,18 +146,19 @@ it('testDrawSimpleDash', function() {
  */
 it('testDrawThickLine', function() {
   var opts = {
-    axes : {
-      x : {
+    axes: {
+      x: {
         drawGrid: false,
-        drawAxis: false,
+        drawAxis: false
       },
-      y : {
+      y: {
         drawGrid: false,
-        drawAxis: false,
+        drawAxis: false
       }
     },
     strokeWidth: 15,
-    colors: ['#ff0000']
+    colors: ['#ff0000'],
+    labels: ['X', 'Y']
   };
 
   var graph = document.getElementById("graph");

--- a/auto_tests/tests/stacked.js
+++ b/auto_tests/tests/stacked.js
@@ -180,7 +180,8 @@ it('testMissingValueAtZero', function() {
 it('testInterpolation', function() {
   var opts = {
     colors: ['#ff0000', '#00ff00', '#0000ff'],
-    stackedGraph: true
+    stackedGraph: true,
+    labels: ['X', 'Y1', 'Y2', 'Y3', 'Y4']
   };
 
   // The last series is all-NaN, it ought to be treated as all zero
@@ -236,7 +237,8 @@ it('testInterpolation', function() {
 it('testInterpolationOptions', function() {
   var opts = {
     colors: ['#ff0000', '#00ff00', '#0000ff'],
-    stackedGraph: true
+    stackedGraph: true,
+    labels: ['X', 'Y1', 'Y2', 'Y3']
   };
 
   var data = [
@@ -277,19 +279,20 @@ it('testMultiAxisInterpolation', function() {
     colors: ['#ff0000', '#00ff00', '#0000ff'],
     stackedGraph: true,
     series: {
-        "Y1": {
-            axis: 'y',
-        },
-        "Y2": {
-            axis: 'y',
-        },
-        "Y3": {
-            axis: 'y2',
-        },
-        "Y4": {
-            axis: 'y2',
-        }
-    }
+      'Y1': {
+        axis: 'y',
+      },
+      'Y2': {
+        axis: 'y',
+      },
+      'Y3': {
+        axis: 'y2',
+      },
+      'Y4': {
+        axis: 'y2',
+      }
+    },
+    labels: ['X', 'Y1', 'Y2', 'Y3', 'Y4']
   };
 
   // The last series is all-NaN, it ought to be treated as all zero

--- a/auto_tests/tests/to_dom_coords.js
+++ b/auto_tests/tests/to_dom_coords.js
@@ -34,14 +34,14 @@ var checkForInverses = function(g) {
 
 it('testPlainChart', function() {
   var opts = {
-    axes : {
-      x : {
+    axes: {
+      x: {
         drawAxis : false,
-        drawGrid : false,
+        drawGrid : false
       },
-      y : {
+      y: {
         drawAxis : false,
-        drawGrid : false,
+        drawGrid : false
       }
     },
     rightGap: 0,
@@ -49,7 +49,8 @@ it('testPlainChart', function() {
     dateWindow: [0, 100],
     width: 400,
     height: 400,
-    colors: ['#ff0000']
+    colors: ['#ff0000'],
+    labels: ['X', 'Y']
   }
 
   var graph = document.getElementById("graph");
@@ -69,12 +70,12 @@ it('testPlainChart', function() {
 
 it('testChartWithAxes', function() {
   var opts = {
-    axes : {
-      x : {
+    axes: {
+      x: {
         drawGrid: false,
         drawAxis: true,
       },
-      y : {
+      y: {
         drawGrid: false,
         drawAxis: true,
         axisLabelWidth: 100
@@ -87,7 +88,8 @@ it('testChartWithAxes', function() {
     dateWindow: [0, 100],
     width: 500,
     height: 450,
-    colors: ['#ff0000']
+    colors: ['#ff0000'],
+    labels: ['X', 'Y']
   }
 
   var graph = document.getElementById("graph");
@@ -103,16 +105,16 @@ it('testChartWithAxes', function() {
 
 it('testChartWithAxesAndLabels', function() {
   var opts = {
-    axes : {
-      x : {
+    axes: {
+      x: {
         drawGrid: false,
         drawAxis: true,
       },
-      y : {
+      y: {
         drawGrid: false,
         drawAxis: true,
         axisLabelWidth: 100
-      }
+      },
     },
     xAxisHeight: 50,
     axisTickSize: 0,
@@ -126,7 +128,8 @@ it('testChartWithAxesAndLabels', function() {
     xlabel: 'This is the x-axis',
     xLabelHeight: 25,
     title: 'This is the title of the chart',
-    titleHeight: 25
+    titleHeight: 25,
+    labels: ['X', 'Y']
   }
 
   var graph = document.getElementById("graph");
@@ -148,7 +151,8 @@ it('testYAxisLabelWidth', function() {
     valueRange: [0, 100],
     dateWindow: [0, 100],
     width: 500,
-    height: 500
+    height: 500,
+    labels: ['X', 'Y']
   }
 
   var graph = document.getElementById("graph");
@@ -172,7 +176,8 @@ it('testAxisTickSize', function() {
     valueRange: [0, 100],
     dateWindow: [0, 100],
     width: 500,
-    height: 500
+    height: 500,
+    labels: ['X', 'Y']
   }
 
   var graph = document.getElementById("graph");
@@ -204,7 +209,8 @@ it('testChartLogarithmic_YAxis', function() {
         drawAxis: false,
         logscale: true
       }
-    }
+    },
+    labels: ['X', 'Y']
   }
 
   var graph = document.getElementById("graph");
@@ -242,7 +248,8 @@ it('testChartLogarithmic_XAxis', function() {
         drawGrid: false,
         drawAxis: false
       }
-    }
+    },
+    labels: ['X', 'Y']
   }
 
   var graph = document.getElementById("graph");

--- a/auto_tests/tests/update_while_panning.js
+++ b/auto_tests/tests/update_while_panning.js
@@ -30,7 +30,8 @@ it('testUpdateWhilePanning', function() {
   var opts = {
     width: 480,
     height: 320,
-    valueRange: [-2, 2]
+    valueRange: [-2, 2],
+    labels: ['X', 'Y']
   };
 
   var graph = document.getElementById("graph");

--- a/package.json
+++ b/package.json
@@ -52,10 +52,15 @@
     "obvious-closure-library": "^20140401.0.2",
     "parse-data-uri": "^0.2.0",
     "phantomjs": "^1.9.7-8",
+    "pre-commit": "^1.0.6",
     "source-map": "^0.4.2",
     "uglify-js": "^2"
   },
   "scripts": {
-    "test": "make test"
-  }
+    "test": "make test",
+    "tests-ok": "./scripts/check-no-only.sh"
+  },
+  "pre-commit": [
+    "tests-ok"
+  ]
 }

--- a/scripts/check-no-only.sh
+++ b/scripts/check-no-only.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Checks that no ".only" has made it into tests. This should never be commited,
+# since it will disable the vast majority of tests.
+
+if grep -R '\.only(' auto_tests/tests; then
+  echo 'Remove .only from tests before committing.'
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
Most of these were "using default labels".

Also adds a precommit hook to ensure that `.only` in a test is never committed. I've made this mistake a few times in the last few days.