### PR TITLE
Add panToTime method

### DIFF
--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -3607,6 +3607,32 @@ Dygraph.prototype.size = function() {
   return { width: this.width_, height: this.height_ };
 };
 
+
+/**
+ * Does programatically panning left or right to ensure that given time is visible on chart when zoomed
+ * @param time in milliseconds
+ */
+Dygraph.prototype.panToTime = function (time) {
+    var g = this;
+    var range = g.xAxisRange();
+    var minDate = range[0];
+    var maxDate = range[1];
+    var delta = 0;
+    if (minDate > time) {
+        delta = time - minDate;
+    }
+    else if (maxDate < time) {
+        delta = time - maxDate;
+    }
+    if (delta != 0) {
+        minDate += delta;
+        maxDate += delta;
+        g.updateOptions({
+            dateWindow: [minDate, maxDate]
+        });
+    }
+};
+
 /**
  * Update the list of annotations and redraw the chart.
  * See dygraphs.com/annotations.html for more info on how to use annotations.


### PR DESCRIPTION
I've added one method that is handy if you want to highlight a point that might be not visible at the moment, because any zoom is applied.
It does panning left or right. This is useful when you are doing something like table-chart synchronization.