### PR TITLE
Dygraph.findPos may return NaN

### DIFF
--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -201,8 +201,8 @@ Dygraph.findPos = function(obj) {
 
   // This handles the case where the object is inside a scrolled div.
   while (obj && obj != document.body) {
-    curleft -= isNaN(obj.scrollLeft) ? 0 : obj.scrollLeft;
-    curtop -= isNaN(obj.scrollTop) ? 0 :obj.scrollTop;
+    curleft -= Dygraph.isOK(obj.scrollLeft) ? obj.scrollLeft : 0;
+    curtop -= Dygraph.isOK(obj.scrollTop) ? obj.scrollTop : 0;
     obj = obj.parentNode;
   }
   return {x: curleft, y: curtop};

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -201,8 +201,8 @@ Dygraph.findPos = function(obj) {
 
   // This handles the case where the object is inside a scrolled div.
   while (obj && obj != document.body) {
-    curleft -= obj.scrollLeft;
-    curtop -= obj.scrollTop;
+    curleft -= isNaN(obj.scrollLeft) ? 0 : obj.scrollLeft;
+    curtop -= isNaN(obj.scrollTop) ? 0 :obj.scrollTop;
     obj = obj.parentNode;
   }
   return {x: curleft, y: curtop};


### PR DESCRIPTION
I embedded a Dygraph into a webcomponent showing several graphs within a elements generated by <template repeat>. Clicks within the graphs did not work correctly. The reason seems to be that the template created a document-fragment around the dygraph element which returned NaN on obj.scrollLeft and obj.scrollTop. The while loop going through all parent nodes up to document.body would pass this document-frament and carry on the NaN returned there.

The consequence was that the x and y returned from Dygraph.findPos resulted in NaN and subsequent calculations failed.