### PR TITLE
allow custom bar series to have the bar continue across missing values

### DIFF
--- a/src/datahandler/bars-custom.js
+++ b/src/datahandler/bars-custom.js
@@ -43,11 +43,7 @@ CustomBarsHandler.prototype.extractSeries = function(rawData, i, options) {
     // Extract to the unified data format.
     if (point !== null) {
       y = point[1];
-      if (y !== null && !isNaN(y)) {
-        series.push([ x, y, [ point[0], point[2] ] ]);
-      } else {
-        series.push([ x, y, [ y, y ] ]);
-      }
+      series.push([ x, y, [ point[0], point[2] ] ]);
     } else {
       series.push([ x, null, [ null, null ] ]);
     }


### PR DESCRIPTION
This is really a convenient hack more than anything else.  Many graphs I produce tend to have a data series containing missing values, along with a model fit (and standard errors) which are continuous across the missing values in the data. You only want the data showing up in legends and the like, thus combining the multiple series by using the custombars dataHandler.

I could produce another dataHandler for this, but it would be identical to bars-custom.js with the exception of this change, which seems overkill.  If there's a smarter way to do this while still keeping the behaviour of inherited missing-ness in the bars as is present currently, am happy to implement (am a javascript noob).