### PR TITLE
Load dygraph-combined when loading from NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dygraphs",
   "version": "1.1.0",
   "description": "dygraphs is a fast, flexible open source JavaScript charting library.",
-  "main": "dygraph.js",
+  "main": "dygraph-combined.js",
   "directories": {
     "doc": "docs",
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dygraphs",
   "version": "1.1.0",
   "description": "dygraphs is a fast, flexible open source JavaScript charting library.",
-  "main": "dygraph-combined.js",
+  "main": "dygraph-combined-dev.js",
   "directories": {
     "doc": "docs",
     "test": "tests"

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -3747,7 +3747,7 @@ Dygraph.addAnnotationRule = function() {
   console.warn("Unable to add default annotation CSS rule; display may be off.");
 };
 
-if (module && module.exports) {
+if (typeof exports === "object" && typeof module !== "undefined") {
   module.exports = Dygraph;
 }
 

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -3747,6 +3747,10 @@ Dygraph.addAnnotationRule = function() {
   console.warn("Unable to add default annotation CSS rule; display may be off.");
 };
 
+if (module && module.exports) {
+  module.exports = Dygraph;
+}
+
 return Dygraph;
 
 })();


### PR DESCRIPTION
Today, when loading dygraphs from NPM via browserify you need to include:

```javascript
var Dygraph  = require('dygraphs/dygraph-combined.js');
```

Being able to do this:
```javascript
var Dygraph  = require('dygraphs');
```

Is preferable.

**UPDATE**
Dygraphs doesn't have a `module.exports` statement, so it can't be loaded via Browserify at all. This PR also includes a fix for this.