### PR TITLE
Fix and regression test for fast proxy artifacts.

### DIFF
--- a/auto_tests/tests/fast_canvas_proxy.js
+++ b/auto_tests/tests/fast_canvas_proxy.js
@@ -98,4 +98,61 @@ it('testSuperfluousSegmentsElided', function() {
                 ['moveTo', 3, 0]], extractMoveToAndLineToCalls(htx));
 });
 
+
+// For a more visual version of this test, see
+// https://gist.github.com/danvk/e98dbb24253c9b153696
+// The drawing commands in the following two tests are taken from there.
+it('should handle gaps on the left', function() {
+  var htx = new Proxy(fakeCanvasContext);
+  var fastProxy = DygraphCanvasRenderer._fastCanvasProxy(htx);
+
+  fastProxy.moveTo(0, 320);
+  fastProxy.lineTo(0, 320);
+  fastProxy.lineTo(53.21, 187);
+  fastProxy.lineTo(53.23, 29);
+  fastProxy.lineTo(53.41, 320);
+  fastProxy.lineTo(54.15, 320);
+  fastProxy.lineTo(475, 320);
+  fastProxy.lineTo(475, 320);
+  fastProxy.fill();
+
+  assert.deepEqual([
+    ['moveTo', 0, 320],
+    ['lineTo', 0, 320],
+    ['lineTo', 53.21, 187],
+    ['lineTo', 53.23, 29],
+    ['lineTo', 53.41, 320],
+    ['lineTo', 54.15, 320],
+    ['lineTo', 475, 320],
+    ['lineTo', 475, 320]
+  ], extractMoveToAndLineToCalls(htx));
+});
+
+it('should handle gaps on the right', function() {
+  var htx = new Proxy(fakeCanvasContext);
+  var fastProxy = DygraphCanvasRenderer._fastCanvasProxy(htx);
+  fastProxy.moveTo(240.2, 320);
+  fastProxy.lineTo(240.2, 320);
+  fastProxy.lineTo(240.2, 174);
+  fastProxy.lineTo(240.7, 145);
+  fastProxy.lineTo(240.8, 320);
+  fastProxy.lineTo(241.3, 29);
+  fastProxy.lineTo(241.4, 320);
+  fastProxy.lineTo(715.9, 320);
+  fastProxy.lineTo(715.9, 320);
+  fastProxy.fill();
+
+  assert.deepEqual([
+    ['moveTo', 240.2, 320],
+    ['lineTo', 240.2, 320],
+    ['lineTo', 240.2, 174],
+    ['lineTo', 240.7, 145],
+    ['lineTo', 240.8, 320],
+    ['lineTo', 241.3, 29],
+    ['lineTo', 241.4, 320],
+    ['lineTo', 715.9, 320],
+    ['lineTo', 715.9, 320]
+  ], extractMoveToAndLineToCalls(htx));
+});
+
 });


### PR DESCRIPTION
Fixes #558

The fix is largely as described in #555, though it needed to be a two-sided check for gaps, not just a one-sided check.