### PR TITLE
Adding xOptView for xfv.call to work properly

### DIFF
--- a/src/extras/super-annotations.js
+++ b/src/extras/super-annotations.js
@@ -315,9 +315,10 @@ annotations.prototype.getTemplateHTML = function(div, a) {
   var col = row_col[1];
 
   var yOptView = g.optionsViewForAxis_('y1');  // TODO: support secondary, too
+  var xOptView = g.optionsViewForAxis_('x');
   var xvf = g.getOptionForAxis('valueFormatter', 'x');
 
-  var x = xvf.call(g, a.xval);
+  var x = xvf.call(g, a.xval, xOptView);
   var y = g.getOption('valueFormatter', a.series).call(
       g, g.getValue(row, col), yOptView);
 


### PR DESCRIPTION
When I try to use the `SuperAnnotations` plugin I get the following error message when I click on a point to create a new annotation:

```
dygraph.js:227 Uncaught TypeError: opts is not a function
```

This PR fixes this error by providing the proper arguments to `xfv.call` inside `annotations.getTemplateHTML` method.