### PR TITLE
Fix XY series highlight positioning

### DIFF
--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1833,21 +1833,34 @@ Dygraph.prototype.findClosestRow = function(domX) {
  * @private
  */
 Dygraph.prototype.findClosestPoint = function(domX, domY) {
-  var minDist = Infinity;
-  var dist, dx, dy, point, closestPoint, closestSeries, closestRow;
+  var minXDist = Infinity;
+  var minYDist = Infinity;
+  var xdist, ydist, dx, dy, point, closestPoint, closestSeries, closestRow;
+
   for ( var setIdx = this.layout_.points.length - 1 ; setIdx >= 0 ; --setIdx ) {
     var points = this.layout_.points[setIdx];
     for (var i = 0; i < points.length; ++i) {
       point = points[i];
       if (!Dygraph.isValidPoint(point)) continue;
+
       dx = point.canvasx - domX;
       dy = point.canvasy - domY;
-      dist = dx * dx + dy * dy;
-      if (dist < minDist) {
-        minDist = dist;
+
+      xdist = dx * dx;
+      ydist = dy * dy;
+
+      if (xdist < minXDist) {
+        minXDist = xdist;
+        minYDist = ydist;
+        closestRow = point.idx;
         closestPoint = point;
         closestSeries = setIdx;
+      } else if (xdist === minXDist && ydist < minYDist) {
+        minXDist = xdist;
+        minYDist = ydist;
         closestRow = point.idx;
+        closestPoint = point;
+        closestSeries = setIdx;
       }
     }
   }


### PR DESCRIPTION
### What
Refactored `findClosetPoint` so that if there is a tie on the X-Axis, the tie-breaker is the point with the closest Y-Axis.  

### Why
Before this commit, when mousing into a graph with highlightSeriesOpts set, the highlighted point / series is the shortest distance from the cursor.  This sounds correct but produces results like this:

<img width="651" alt="screen shot 2015-07-15 at 9 39 24 pm" src="https://cloud.githubusercontent.com/assets/7582765/8715635/1e5b6f20-2b3a-11e5-8f9e-b048b5b68464.png">

With this change, the correct points and series are highlighted:

<img width="731" alt="screen shot 2015-07-15 at 9 39 00 pm" src="https://cloud.githubusercontent.com/assets/7582765/8715636/251de91e-2b3a-11e5-98a3-15090528ca37.png">



