### PR TITLE
Add support to boolean array in setVisibility function

### DIFF
--- a/auto_tests/tests/visibility.js
+++ b/auto_tests/tests/visibility.js
@@ -67,4 +67,14 @@ it('testMultiSeriesShow', function() {
   assert.equal(' B  D', getVisibleSeries(false, [[1,3], true]));
 });
 
+it('testValueAsArray', function() {
+  assert.equal(' B  D', getVisibleSeries(false, [[1,2,3], [true,false,true]]));
+});
+
+it('testValueArgumentOfDifferentLength', function() {
+  assert.throws(function(){ getVisibleSeries(false, [[1,2,3], [true, true]]) },
+    Error, "The value argument of setVisibility must have the same " +
+           "length of the num argument when passed as an array.");
+});
+
 });

--- a/auto_tests/tests/visibility.js
+++ b/auto_tests/tests/visibility.js
@@ -67,14 +67,8 @@ it('testMultiSeriesShow', function() {
   assert.equal(' B  D', getVisibleSeries(false, [[1,3], true]));
 });
 
-it('testValueAsArray', function() {
-  assert.equal(' B  D', getVisibleSeries(false, [[1,2,3], [true,false,true]]));
-});
-
-it('testValueArgumentOfDifferentLength', function() {
-  assert.throws(function(){ getVisibleSeries(false, [[1,2,3], [true, true]]) },
-    Error, "The value argument of setVisibility must have the same " +
-           "length of the num argument when passed as an array.");
+it('testObjectSeriesShowAndHide', function() {
+  assert.equal(' B  D', getVisibleSeries(false, [{1:true, 2:false, 3:true}, null]));
 });
 
 });

--- a/auto_tests/tests/visibility.js
+++ b/auto_tests/tests/visibility.js
@@ -71,4 +71,8 @@ it('testObjectSeriesShowAndHide', function() {
   assert.equal(' B  D', getVisibleSeries(false, [{1:true, 2:false, 3:true}, null]));
 });
 
+it('testBooleanArraySeriesShowAndHide', function() {
+  assert.equal(' B  D', getVisibleSeries(false, [[false, true, false, true], null]));
+});
+
 });

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -3578,10 +3578,10 @@ Dygraph.prototype.visibility = function() {
 /**
  * Changes the visibility of one or more series.
  *
- * @param {number|number[]|object} num the series index  or an array of series indices
-                                       or an object mapping series numbers, as keys, to 
-                                       visibility state (boolean values)
- *                                      
+ * @param {number|number[]|object} num the series index or an array of series indices
+ *                                     or a boolean array of visibility states by index
+ *                                     or an object mapping series numbers, as keys, to 
+ *                                     visibility state (boolean values)
  * @param {boolean} value the visibility state expressed as a boolean
  */
 Dygraph.prototype.setVisibility = function(num, value) {
@@ -3608,10 +3608,18 @@ Dygraph.prototype.setVisibility = function(num, value) {
     }
   } else {
     for (var i = 0; i < num.length; i++) {
-     if (num[i] < 0 || num[i] >= x.length) {
-        console.warn("Invalid series number in setVisibility: " + num[i]);
+      if (typeof num[i] === 'boolean') {
+        if (i >= x.length) {
+          console.warn("Invalid series number in setVisibility: " + i);
+        } else {
+          x[i] = num[i];
+        }
       } else {
-        x[num[i]] = value;
+        if (num[i] < 0 || num[i] >= x.length) {
+          console.warn("Invalid series number in setVisibility: " + num[i]);
+        } else {
+          x[num[i]] = value;
+        }
       }
     }
   }

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -3579,18 +3579,29 @@ Dygraph.prototype.visibility = function() {
  * Changes the visibility of one or more series.
  *
  * @param {number|number[]} num the series index or an array of series indices
- * @param {boolean} value true or false, identifying the visibility.
+ * @param {boolean|boolean[]} value the visibility state expressed as a single 
+ *                                  boolean or an array of boolean equally 
+ *                                  sized to the num argument array
  */
 Dygraph.prototype.setVisibility = function(num, value) {
   var x = this.visibility();
+  var valueIsArray = Array.isArray(value);
 
-  if (num.constructor !== Array) num = [num];
+  if (!Array.isArray(num)) num = [num];
+  
+  // check if second argument is an array and, if so, is of the same length
+  if (valueIsArray) {
+    if (value.length != num.length) {
+      throw new Error("The value argument of setVisibility must have the same" +
+                      " length of the num argument when passed as an array.");
+    }
+  }
 
   for (var i = 0; i < num.length; i++) {
     if (num[i] < 0 || num[i] >= x.length) {
-      console.warn("invalid series number in setVisibility: " + num[i]);
+      console.warn("Invalid series number in setVisibility: " + num[i]);
     } else {
-      x[num[i]] = value;
+      x[num[i]] = valueIsArray ? value[i] : value;
     }
   }
 

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -3578,30 +3578,41 @@ Dygraph.prototype.visibility = function() {
 /**
  * Changes the visibility of one or more series.
  *
- * @param {number|number[]} num the series index or an array of series indices
- * @param {boolean|boolean[]} value the visibility state expressed as a single 
- *                                  boolean or an array of boolean equally 
- *                                  sized to the num argument array
+ * @param {number|number[]|object} num the series index  or an array of series indices
+                                       or an object mapping series numbers, as keys, to 
+                                       visibility state (boolean values)
+ *                                      
+ * @param {boolean} value the visibility state expressed as a boolean
  */
 Dygraph.prototype.setVisibility = function(num, value) {
   var x = this.visibility();
-  var valueIsArray = Array.isArray(value);
+  var numIsObject = false;
 
-  if (!Array.isArray(num)) num = [num];
-  
-  // check if second argument is an array and, if so, is of the same length
-  if (valueIsArray) {
-    if (value.length != num.length) {
-      throw new Error("The value argument of setVisibility must have the same" +
-                      " length of the num argument when passed as an array.");
+  if (!Array.isArray(num)) {
+    if (num !== null && typeof num === 'object') {
+      numIsObject = true;
+    } else {
+      num = [num];
     }
   }
 
-  for (var i = 0; i < num.length; i++) {
-    if (num[i] < 0 || num[i] >= x.length) {
-      console.warn("Invalid series number in setVisibility: " + num[i]);
-    } else {
-      x[num[i]] = valueIsArray ? value[i] : value;
+  if (numIsObject) {
+    for (var i in num) {
+      if (num.hasOwnProperty(i)) {
+        if (i < 0 || i >= x.length) {
+          console.warn("Invalid series number in setVisibility: " + i);
+        } else {
+          x[i] = num[i];
+        }
+      }
+    }
+  } else {
+    for (var i = 0; i < num.length; i++) {
+     if (num[i] < 0 || num[i] >= x.length) {
+        console.warn("Invalid series number in setVisibility: " + num[i]);
+      } else {
+        x[num[i]] = value;
+      }
     }
   }
 


### PR DESCRIPTION
This PR enables setVisibility to accept value as an array, so one can do:
```javascript
graph.setVisibility([1,2,3], [true,false,true]);
```

If the boolean array have a different length of the num argument, then an error is thrown.

Previous behavior hasn't changed.

Tests added for both success and fail cases.

Additionally, this patch solves the array check issue related in https://github.com/danvk/dygraphs/pull/560#discussion-diff-36852612

If I missed something, please let me know and I'll try to adjust the code.