### PR TITLE
Add a legendFormatter option

### DIFF
--- a/auto_tests/tests/plugins_legend.js
+++ b/auto_tests/tests/plugins_legend.js
@@ -76,4 +76,41 @@ it('should render dashed patterns', function() {
                'rgb(255, 0, 0)');
 });
 
+it('should use a legendFormatter', function() {
+  var calls = [];
+  var g = new Dygraph(graph, 'X,Y\n1,2\n', {
+    color: 'red',
+    legend: 'always',
+    legendFormatter: function(data) {
+      calls.push(data);
+      // Note: can't check against `g` because it's not defined yet.
+      assert(this.toString().indexOf('Dygraph') >= 0);
+      return '';
+    }
+  });
+
+  assert(calls.length == 1);  // legend for no selected points
+  g.setSelection(0);
+  assert(calls.length == 2);  // legend with selected points
+  g.clearSelection();
+  assert(calls.length == 3);
+
+  assert.equal(calls[0].x, undefined);
+  assert.equal(calls[1].x, 1);
+  assert.equal(calls[1].xHTML, '1');
+  assert.equal(calls[2].x, undefined);
+
+  assert.equal(calls[0].series.length, 1);
+  assert.equal(calls[1].series.length, 1);
+  assert.equal(calls[2].series.length, 1);
+
+  assert.equal(calls[0].series[0].y, undefined);
+  assert.equal(calls[1].series[0].label, 'Y');
+  assert.equal(calls[1].series[0].labelHTML, 'Y');
+  assert.equal(calls[1].series[0].y, 2);
+  assert.equal(calls[1].series[0].yHTML, '2');
+  assert.equal(calls[1].series[0].isVisible, true);
+  assert.equal(calls[2].series[0].y, undefined);
+});
+
 });

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -466,8 +466,11 @@ OPTIONS_REFERENCE =  // <JSON>
   "legendFormatter": {
     "default": "null",
     "labels": ["Legend"],
-    "type": "function",
-    "description": "Set this to supply a custom formatter for the legend. See ..."
+    "type": "function(data): string",
+    "params": [
+      [ "data", "An object containing information about the selection (or lack of a selection). This includes formatted values and series information. See <a href=\"https://github.com/danvk/dygraphs/pull/683\">here</a> for sample values." ]
+    ],
+    "description": "Set this to supply a custom formatter for the legend. See <a href=\"https://github.com/danvk/dygraphs/pull/683\">this comment</a> and the <a href=\"tests/legend-formatter.html\">legendFormatter demo</a> for usage."
   },
   "labelsShowZeroValues": {
     "default": "true",

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -463,6 +463,12 @@ OPTIONS_REFERENCE =  // <JSON>
     "type": "string",
     "description": "When to display the legend. By default, it only appears when a user mouses over the chart. Set it to \"always\" to always display a legend of some sort. When set to \"follow\", legend follows highlighted points."
   },
+  "legendFormatter": {
+    "default": "null",
+    "labels": ["Legend"],
+    "type": "function",
+    "description": "Set this to supply a custom formatter for the legend. See ..."
+  },
   "labelsShowZeroValues": {
     "default": "true",
     "labels": ["Legend"],

--- a/tests/legend-formatter.html
+++ b/tests/legend-formatter.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<title>legendFormatter</title>
+<style>
+#demodiv {
+  width: 640px;
+  height: 480px;
+  display: inline-block;
+  vertical-align: top;
+}
+#legend {
+  display: inline-block;
+  vertical-align: top;
+}
+</style>
+
+<h2>legendFormatter</h2>
+<p>This page demonstrates use of <a href="../options.html#legendFormatter"><code>legendFormatter</code></a>, which can be used to create more complex legends than <code>valueFormatter</code>.</p>
+<div id="demodiv"></div>
+<div id="legend"></div>
+
+<script type="text/javascript" src="../dist/dygraph.js"></script>
+<script type="text/javascript">
+function legendFormatter(data) {
+  if (data.x == null) {
+    // This happens when there's no selection and {legend: 'always'} is set.
+    return '<br>' + data.series.map(function(series) { return series.dashHTML + ' ' + series.labelHTML }).join('<br>');
+  }
+
+  var html = this.getLabels()[0] + ': ' + data.xHTML;
+  data.series.forEach(function(series) {
+    if (!series.isVisible) return;
+    var labeledData = series.labelHTML + ': ' + series.yHTML;
+    if (series.isHighlighted) {
+      labeledData = '<b>' + labeledData + '</b>';
+    }
+    html += '<br>' + series.dashHTML + ' ' + labeledData;
+  });
+  return html;
+}
+
+new Dygraph(
+    document.getElementById("demodiv"),
+    function() {
+      var zp = function(x) { if (x < 10) return "0"+x; else return x; };
+      var r = "date,parabola,line,another line,sine wave\n";
+      for (var i=1; i<=31; i++) {
+      r += "200610" + zp(i);
+      r += "," + 10*(i*(31-i));
+      r += "," + 10*(8*i);
+      r += "," + 10*(250 - 8*i);
+      r += "," + 10*(125 + 125 * Math.sin(0.3*i));
+      r += "\n";
+      }
+      return r;
+    },
+    {
+      labelsDiv: document.getElementById('status'),
+      labelsKMB: true,
+      colors: ["rgb(51,204,204)",
+               "rgb(255,100,100)",
+               "#00DD55",
+               "rgba(50,50,200,0.4)"],
+      title: 'Interesting Shapes',
+      xlabel: 'Date',
+      ylabel: 'Count',
+      highlightSeriesOpts: { strokeWidth: 2 },
+      labelsDiv: document.getElementById('legend'),
+      legend: 'always',
+      legendFormatter: legendFormatter
+    }
+);
+</script>


### PR DESCRIPTION
This is intended to be a catch-all for legend formatting needs. This [comes][1] [up][2] [often][3] in Stack Overflow [questions][4] which can't be easily answered with `valueFormatter`. Nowadays I wave my hands and say "write your own legend, either as a plugin or using `highlightCallback` and `unhighlightCallback`." This is a simpler option.

The `legendFormatter` is repeatedly called with a `data` object describing the selection or lack of selection. It contains all the information you need to generate a standard legend (e.g. formatted values), but there's nothing preventing you from doing something crazier on your own.

For example, here's what a simple `legendFormatter` might look like:

```javascript
function legendFormatter(data) {
  if (data.x == null) return '';  // no selection
  return data.xHTML + data.series.map(v => v.labelHTML + ': ' + v.yHTML).join(' ');
}
```

Here's what the `data` object looks like when nothing is selected:

```json
{
  "dygraph": "(dygraph)",
  "series": [
    {
      "dashHTML": "<div style=\"display: inline-block; position: relative; bottom: .5ex; padding-left: 1em; height: 1px; border-bottom: 2px solid rgb(0,128,0);\"></div>",
      "label": "Y1",
      "labelHTML": "Y1",
      "visible": true,
      "color": "rgb(0,128,0)"
    },
    {
      "dashHTML": "<div style=\"display: inline-block; position: relative; bottom: .5ex; padding-left: 1em; height: 1px; border-bottom: 2px solid rgb(0,0,128);\"></div>",
      "label": "Y2",
      "labelHTML": "Y2",
      "visible": true,
      "color": "rgb(0,0,128)"
    }
  ]
}
```

The `dashHTML` properties help you render lines which match each series' line on the chart. When `strokePattern` is set, they become dotted or dashed lines as needed.

Each value has a corresponding `HTML` variant, which is properly formatted and escaped according to all the relevant options which have been set for the chart.

Here's what it looks like when a row is selected:

```json
{
  "dygraph": "(dygraph)",
  "x": 93,
  "xHTML": 93,
  "series": [
    {
      "dashHTML": "<div style=\"display: inline-block; position: relative; bottom: .5ex; padding-left: 1em; height: 1px; border-bottom: 2px solid rgb(0,128,0);\"></div>",
      "label": "Y1",
      "labelHTML": "Y1",
      "visible": true,
      "color": "rgb(0,128,0)",
      "y": 93,
      "yHTML": "93"
    },
    {
      "dashHTML": "<div style=\"display: inline-block; position: relative; bottom: .5ex; padding-left: 1em; height: 1px; border-bottom: 2px solid rgb(0,0,128);\"></div>",
      "label": "Y2",
      "labelHTML": "Y2",
      "visible": true,
      "color": "rgb(0,0,128)",
      "y": 26.04,
      "yHTML": "26.04"
    }
  ]
}
```

Here's what it looks like when a single series is selected (e.g. with `highlightSeriesOpts`):

```json
{
  "dygraph": "(dygraph)",
  "x": 94,
  "xHTML": 94,
  "series": [
    {
      "dashHTML": "<div style=\"display: inline-block; position: relative; bottom: .5ex; padding-left: 1em; height: 1px; border-bottom: 2px solid rgb(0,128,0);\"></div>",
      "label": "Y1",
      "labelHTML": "Y1",
      "visible": true,
      "color": "rgb(0,128,0)",
      "y": 94,
      "yHTML": "94",
      "isHighlighted": true
    },
    {
      "dashHTML": "<div style=\"display: inline-block; position: relative; bottom: .5ex; padding-left: 1em; height: 1px; border-bottom: 2px solid rgb(0,0,128);\"></div>",
      "label": "Y2",
      "labelHTML": "Y2",
      "visible": true,
      "color": "rgb(0,0,128)",
      "y": 22.56,
      "yHTML": "22.56"
    }
  ]
}
```
(Note the `isHighlighted` property set on `Y1`.)

Fixes #407 

[1]: http://stackoverflow.com/a/25090552/388951
[2]: http://stackoverflow.com/a/24175648/388951
[3]: http://stackoverflow.com/a/18211338/388951
[4]: http://stackoverflow.com/a/23354308/388951