### PR TITLE
Feature: Selection Modes

### DIFF
--- a/auto_tests/tests/select_closest_x.js
+++ b/auto_tests/tests/select_closest_x.js
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2015 Dan Vanderkam (danvdk@gmail.com)
+ * MIT-licensed (http://opensource.org/licenses/MIT)
+ */
+
+/**
+ * @fileoverview Test the selectByClosestX selection mode.
+ * @author musicist288@gmail.com (Joseph Rossi)
+ */
+
+import Dygraph from '../../src/dygraph';
+import * as utils from '../../src/dygraph-utils';
+
+describe("selection by closest x", function() {
+
+cleanupAfterEach();
+
+it('selects the closest previous value', function () {
+  var data = 'X,A,B\n' +
+             '100, ,2\n' +
+             '200,3, \n';
+
+  var calls = [];
+  function cb(g, seriesName, canvasContext, cx, cy, color, pointSize, idx) {
+    calls.push(arguments);
+    utils.Circles.DEFAULT.apply(this, arguments);
+  }
+
+  var g = new Dygraph(document.getElementById("graph"), data, {
+    drawHighlightPointCallback: cb,
+    selectionMode: Dygraph.SelectionModes.selectByClosestX
+  });
+
+  g.setSelection(1);
+  assert.equal(calls.length, 2);
+  var expectedA = g.toDomCoords(200, 3);
+  var aCall = calls[0];
+  assert.equal(aCall[1], 'A');
+
+  // Some implementation detail results in point.canvasy
+  // and g.toDomYCoord(point.yval) to be ever so slightly
+  // different, but not enough to be significant.
+  var acceptableError = 1e-9;
+  var difference = Math.abs(aCall[4] - expectedA[1]);
+  assert.isTrue(difference < acceptableError);
+  difference = Math.abs(aCall[3] - expectedA[0]);
+  assert.isTrue(difference < acceptableError);
+
+  var expectedB = g.toDomCoords(100, 2);
+  var bCall = calls[1];
+  assert.equal(bCall[1], 'B');
+
+  difference = Math.abs(bCall[3] - expectedB[0]);
+  assert.isTrue(difference < acceptableError);
+
+  difference = Math.abs(bCall[4] - expectedB[1]);
+  assert.isTrue(difference < acceptableError);
+});
+
+it('does not select from rows greater than the closest row', function () {
+  var data = 'X,A,B\n' +
+             '1, , \n' +
+             '2,3, \n' +
+             '3,4,5\n';
+
+  var calls = [];
+  function cb(g, seriesName, canvasContext, cx, cy, color, pointSize, idx) {
+    calls.push(arguments);
+    utils.Circles.DEFAULT.apply(this, arguments);
+  }
+
+  var g = new Dygraph(document.getElementById("graph"), data, {
+    drawHighlightPointCallback: cb,
+    selectionMode: Dygraph.SelectionModes.selectByClosestX
+  });
+
+  g.setSelection(1);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][1], 'A');
+});
+
+it('uses the greatest xval of the selected points', function () {
+  var selectCalls = [];
+  var plugin = function () {}
+  plugin.prototype.activate = function () {
+    return {
+      select: function(e) {
+        selectCalls.push(e);
+      }
+    };
+  };
+
+  var data = 'X,A,B\n' +
+             '1, , \n' +
+             '2,3, \n' +
+             '3,4,5\n' +
+             '4, ,2\n';
+
+  var g = new Dygraph(document.getElementById("graph"), data, {
+    plugins: [plugin],
+    selectionMode: Dygraph.SelectionModes.selectByClosestX
+  });
+
+  g.setSelection(3);
+  assert.equal(selectCalls.length, 1);
+  assert.equal(selectCalls[0].selectedX, '4');
+});
+
+});

--- a/src/dygraph-default-attrs.js
+++ b/src/dygraph-default-attrs.js
@@ -4,6 +4,7 @@ import * as DygraphTickers from './dygraph-tickers';
 import DygraphInteraction from './dygraph-interaction-model';
 import DygraphCanvasRenderer from './dygraph-canvas';
 import * as utils from './dygraph-utils';
+import * as DygraphSelectionModes from './dygraph-selection-modes';
 
 // Default attribute values.
 var DEFAULT_ATTRS = {
@@ -130,7 +131,9 @@ var DEFAULT_ATTRS = {
       independentTicks: false,
       ticker: DygraphTickers.numericTicks
     }
-  }
+  },
+
+  selectionMode: DygraphSelectionModes.selectByRow
 };
 
 export default DEFAULT_ATTRS;

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -844,6 +844,18 @@ OPTIONS_REFERENCE =  // <JSON>
     "labels": ["Data"],
     "type": "Dygraph.DataHandler",
     "description": "Custom DataHandler. This is an advanced customization. See http://bit.ly/151E7Aq."
+  },
+  "selectionMode": {
+    "default": "Dygraph.SelectionModes.selectByRow",
+    "labels": ["Configuration"],
+    "type": "function (seriesPoints, closestRowIndex, graph)",
+    "parameters": [
+      ["seriesPoints", "An array where each entry is an array of points for a series."],
+      ["closestRowIndex", "The closests row to use for selection points."],
+      ["dygraph", "The referenced graph"]
+    ],
+    "returns": "Array<points>",
+    "description": "This function is called every time the selection changes. It's return value is used as the set of selected points for highlighting, reporting legend values, etc."
   }
 }
 ;  // </JSON>

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -851,8 +851,7 @@ OPTIONS_REFERENCE =  // <JSON>
     "type": "function (seriesPoints, closestRowIndex, graph)",
     "parameters": [
       ["seriesPoints", "An array where each entry is an array of points for a series."],
-      ["closestRowIndex", "The closest row to use for selection points."],
-      ["dygraph", "The referenced graph"]
+      ["closestRowIndex", "The closest row to use for selection points."]
     ],
     "returns": "Array<points>",
     "description": "This function is called every time the selection changes. Its return value is used as the set of selected points for highlighting, reporting legend values, etc."

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -851,11 +851,11 @@ OPTIONS_REFERENCE =  // <JSON>
     "type": "function (seriesPoints, closestRowIndex, graph)",
     "parameters": [
       ["seriesPoints", "An array where each entry is an array of points for a series."],
-      ["closestRowIndex", "The closests row to use for selection points."],
+      ["closestRowIndex", "The closest row to use for selection points."],
       ["dygraph", "The referenced graph"]
     ],
     "returns": "Array<points>",
-    "description": "This function is called every time the selection changes. It's return value is used as the set of selected points for highlighting, reporting legend values, etc."
+    "description": "This function is called every time the selection changes. Its return value is used as the set of selected points for highlighting, reporting legend values, etc."
   }
 }
 ;  // </JSON>

--- a/src/dygraph-selection-modes.js
+++ b/src/dygraph-selection-modes.js
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2015 Dan Vanderkam (danvdk@gmail.com)
+ * MIT-licensed (http://opensource.org/licenses/MIT)
+ */
+
+/**
+ * @fileOverview These functions determine the actual points to include
+ * in the selection set.  Any exported functions will automatically be
+ * registered on Dygraph.SelectionModes (defined in dygraphs.js).
+ *
+ * @name dygraph-selection-modes.js
+ * @author musicist288@gmail.com (Joseph Rossi)
+ */
+
+/**
+ * The default selection mode returns points that strictly from the selected
+ * row. If the value for that point is undefined, this mode does not attempt
+ * to find an alternate value for the selection.
+ *
+ * @param {Array<Array<Dygraph.PointType>>} seriesPoints, An array of series
+       points
+ * @param {number} closestRowIndex, The index of the closest row for the selection.
+ * @param {Dygraph} graph, The dygraph instance.
+ * @returns {Array<Dygraph.PointType>} An array of points to act as the new
+ *     selection
+ */
+export var selectByRow = function (seriesPoints, closestRowIndex, dygraph) {
+  var selection = [];
+  var point;
+  for (var setIdx = 0; setIdx < seriesPoints.length; ++setIdx) {
+    var points = seriesPoints[setIdx];
+    // Check if the point at the appropriate index is the point we're looking
+    // for.  If it is, just use it, otherwise search the array for a point
+    // in the proper place.
+    var setRow = closestRowIndex - dygraph.getLeftBoundary_(setIdx);
+    if (setRow < points.length && points[setRow].idx == closestRowIndex) {
+      point = points[setRow];
+      if (point.yval !== null) selection.push(point);
+    } else {
+      for (var pointIdx = 0; pointIdx < points.length; ++pointIdx) {
+        point = points[pointIdx];
+        if (point.idx == closestRowIndex) {
+          if (point.yval !== null) {
+            selection.push(point);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return selection;
+};
+
+/**
+ * Tries to match point strictly based on the selected row. If a point's value
+ * is not defined for the selected row, the closest point from each series
+ * less than the selected row will be included in the selection.
+ *
+ * @param {Array<Array<Dygraph.PointType>>} seriesPoints, An array of series
+       points
+ * @param {number} closestRowIndex, The index of the closest row for the selection.
+ * @param {Dygraph} graph, The dygraph instance.
+ * @returns {Array<Dygraph.PointType>} An array of points to act as the new
+ *     selection
+ */
+export var selectByClosestX = function (seriesPoints, closestRowIndex, dygraph) {
+  var selection = [];
+  var point;
+  for (var setIdx = 0; setIdx < seriesPoints.length; ++setIdx) {
+    var points = seriesPoints[setIdx];
+    var setRow = closestRowIndex - dygraph.getLeftBoundary_(setIdx);
+    if (setRow < points.length && points[setRow].idx == closestRowIndex) {
+      point = points[setRow];
+      if (point.yval !== null && point.yval !== undefined && !isNaN(point.yval)) {
+        selection.push(point);
+      } else {
+        for (var i = setRow - 1; i >= 0; i--) {
+          point = points[i];
+          if (point.yval !== null && point.yval !== undefined && !isNaN(point.yval)) {
+            selection.push(point);
+            break;
+          }
+        }
+      }
+    } else {
+      for (var pointIdx = 0; pointIdx < points.length; ++pointIdx) {
+        point = points[pointIdx];
+        if (point.idx == closestRowIndex) {
+          if (point.yval !== null) {
+            selection.push(point);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return selection;
+};

--- a/src/dygraph-selection-modes.js
+++ b/src/dygraph-selection-modes.js
@@ -5,18 +5,18 @@
  */
 
 /**
- * @fileOverview These functions determine the actual points to include
+ * @fileoverview These functions determine the actual points to include
  * in the selection set.  Any exported functions will automatically be
- * registered on Dygraph.SelectionModes (defined in dygraphs.js).
+ * registered on Dygraph.SelectionModes (defined in dygraph.js).
  *
  * @name dygraph-selection-modes.js
  * @author musicist288@gmail.com (Joseph Rossi)
  */
 
 /**
- * The default selection mode returns points that strictly from the selected
- * row. If the value for that point is undefined, this mode does not attempt
- * to find an alternate value for the selection.
+ * The default selection mode returns points from the selected row. If the
+ * value for that point is undefined, this mode does not attempt to find an
+ * alternate value for the selection.
  *
  * @param {Array<Array<Dygraph.PointType>>} seriesPoints, An array of series
        points

--- a/src/dygraph-selection-modes.js
+++ b/src/dygraph-selection-modes.js
@@ -21,11 +21,10 @@
  * @param {Array<Array<Dygraph.PointType>>} seriesPoints, An array of series
        points
  * @param {number} closestRowIndex, The index of the closest row for the selection.
- * @param {Dygraph} graph, The dygraph instance.
  * @returns {Array<Dygraph.PointType>} An array of points to act as the new
  *     selection
  */
-export var selectByRow = function (seriesPoints, closestRowIndex, dygraph) {
+export var selectByRow = function (seriesPoints, closestRowIndex) {
   var selection = [];
   var point;
   for (var setIdx = 0; setIdx < seriesPoints.length; ++setIdx) {
@@ -33,7 +32,7 @@ export var selectByRow = function (seriesPoints, closestRowIndex, dygraph) {
     // Check if the point at the appropriate index is the point we're looking
     // for.  If it is, just use it, otherwise search the array for a point
     // in the proper place.
-    var setRow = closestRowIndex - dygraph.getLeftBoundary_(setIdx);
+    var setRow = closestRowIndex - this.getLeftBoundary_(setIdx);
     if (setRow < points.length && points[setRow].idx == closestRowIndex) {
       point = points[setRow];
       if (point.yval !== null) selection.push(point);
@@ -61,16 +60,15 @@ export var selectByRow = function (seriesPoints, closestRowIndex, dygraph) {
  * @param {Array<Array<Dygraph.PointType>>} seriesPoints, An array of series
        points
  * @param {number} closestRowIndex, The index of the closest row for the selection.
- * @param {Dygraph} graph, The dygraph instance.
  * @returns {Array<Dygraph.PointType>} An array of points to act as the new
  *     selection
  */
-export var selectByClosestX = function (seriesPoints, closestRowIndex, dygraph) {
+export var selectByClosestX = function (seriesPoints, closestRowIndex) {
   var selection = [];
   var point;
   for (var setIdx = 0; setIdx < seriesPoints.length; ++setIdx) {
     var points = seriesPoints[setIdx];
-    var setRow = closestRowIndex - dygraph.getLeftBoundary_(setIdx);
+    var setRow = closestRowIndex - this.getLeftBoundary_(setIdx);
     if (setRow < points.length && points[setRow].idx == closestRowIndex) {
       point = points[setRow];
       if (point.yval !== null && point.yval !== undefined && !isNaN(point.yval)) {

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1859,7 +1859,7 @@ Dygraph.prototype.setSelection = function(row, opt_seriesName, opt_locked) {
   if (row !== false && row >= 0) {
     if (row != this.lastRow_) changed = true;
     this.lastRow_ = row;
-    this.selPoints_ = selectionMode(this.layout_.points, row, this);
+    this.selPoints_ = selectionMode.call(this, this.layout_.points, row);
   } else {
     if (this.lastRow_ >= 0) changed = true;
     this.lastRow_ = -1;

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -3575,12 +3575,7 @@ Dygraph.DataHandlers = {
 };
 
 
-Dygraph.SelectionModes = {};
-// Auto populate Dygraph.SelectionModes with exported
-// functions.
-for (var key in DygraphSelectionModes) {
-  Dygraph.SelectionModes[key] = DygraphSelectionModes[key];
-}
+Dygraph.SelectionModes = DygraphSelectionModes;
 
 Dygraph.startPan = DygraphInteraction.startPan;
 Dygraph.startZoom = DygraphInteraction.startZoom;


### PR DESCRIPTION
This is a proposed implementation for https://github.com/danvk/dygraphs/issues/371.

Selection modes are defined in `src/dygraph-selection-modes.js` with the
ability to override them on a per graph basis with the option
`selectionMode` when instantiating the Dygraph.

>This is a generalized approach of the changes I needed to make for my company's use case. These changes represent the bare minimum; I wasn't sure if I should go as far as to define a whole selection model implementation (similar to the plug-in system). Our use case revolves exclusively around time series data so there may be some decisions made that are influenced by that case and may not fit the general approach.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/danvk/dygraphs/696)
<!-- Reviewable:end -->
