### PR TITLE
Pass seriesData canvasx + canvasy point coordinates to legendFormatter

### DIFF
--- a/src/plugins/legend.js
+++ b/src/plugins/legend.js
@@ -268,6 +268,10 @@ Legend.generateLegendHTML = function(g, x, sel_points, oneEmWidth, row) {
       var seriesData = labelToSeries[pt.name];
       seriesData.y = pt.yval;
 
+      // Add canvas location to returned series data
+      seriesData.canvasx = pt.canvasx;
+      seriesData.canvasy = pt.canvasy;
+
       if ((pt.yval === 0 && !showZeros) || isNaN(pt.canvasy)) {
         seriesData.isVisible = false;
         continue;
@@ -354,7 +358,7 @@ generateLegendDashHTML = function(strokePattern, color, oneEmWidth) {
   var normalizedPattern = [];
   var loop;
 
-  // Compute the length of the pixels including the first segment twice, 
+  // Compute the length of the pixels including the first segment twice,
   // since we repeat it.
   for (i = 0; i <= strokePattern.length; i++) {
     strokePixelLength += strokePattern[i%strokePattern.length];


### PR DESCRIPTION
This allows legendFormatter to make use of CSS positioning for individual series data. 