### PR TITLE
Bugfix: Import missing dygraph-utils.js

### DIFF
--- a/src/iframe-tarp.js
+++ b/src/iframe-tarp.js
@@ -23,6 +23,8 @@
  *
  * @constructor
  */
+import * as utils from './dygraph-utils';
+
 function IFrameTarp() {
   /** @type {Array.<!HTMLDivElement>} */
   this.tarps = [];


### PR DESCRIPTION
The IFrameTarp.prototype.cover function calls `findPos` from the `dygraph-utils.js` file but does not import it. 
This fixes #724 