### PR TITLE
Bug fix: indexFromSetName on invisible sets

### DIFF
--- a/auto_tests/tests/data_api.js
+++ b/auto_tests/tests/data_api.js
@@ -4,6 +4,7 @@
  * @author danvdk@gmail.com (Dan Vanderkam)
  */
 import Dygraph from '../../src/dygraph';
+import * as utils from '../../src/dygraph-utils';
 describe("data-api", function() {
 
 cleanupAfterEach();
@@ -103,7 +104,7 @@ it('testGetRowForXDuplicates', function() {
 // In 1.1.1, if you request the last set and it's invisible, the method returns undefined.
 it('testIndexFromSetNameOnInvisibleSet', function() {
   
-  var localOpts = opts;
+  var localOpts = utils.clone(opts);
   localOpts.visibility = [true, false];
 
   var g = new Dygraph(graphDiv, [

--- a/auto_tests/tests/data_api.js
+++ b/auto_tests/tests/data_api.js
@@ -104,7 +104,7 @@ it('testGetRowForXDuplicates', function() {
 it('testIndexFromSetNameOnInvisibleSet', function() {
   
   var localOpts = opts;
-  localOpts.visibility = [true, true];
+  localOpts.visibility = [true, false];
 
   var g = new Dygraph(graphDiv, [
     "x,y1,y2",

--- a/auto_tests/tests/data_api.js
+++ b/auto_tests/tests/data_api.js
@@ -99,4 +99,21 @@ it('testGetRowForXDuplicates', function() {
   assert.equal(5, g.getRowForX(9));
 });
 
+// indexFromSeriesName should return a value even if the series is invisible
+// In 1.1.1, if you request the last set and it's invisible, the method returns undefined.
+it('testIndexFromSetNameOnInvisibleSet', function() {
+  
+  var localOpts = opts;
+  localOpts.visibility = [true, true];
+
+  var g = new Dygraph(graphDiv, [
+    "x,y1,y2",
+    "1,1,1",
+    "2,2,2",
+    "3,3,3"
+  ].join('\n'), localOpts);
+
+  assert.equal(2, g.indexFromSetName("y2"));
+});
+
 });

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -2304,15 +2304,14 @@ Dygraph.prototype.drawGraph_ = function() {
 
   this.setIndexByName_ = {};
   var labels = this.attr_("labels");
-  if (labels.length > 0) {
-    this.setIndexByName_[labels[0]] = 0;
-  }
   var dataIdx = 0;
   for (var i = 1; i < points.length; i++) {
-    this.setIndexByName_[labels[i]] = i;
     if (!this.visibility()[i - 1]) continue;
     this.layout_.addDataset(labels[i], points[i]);
     this.datasetIndex_[i] = dataIdx++;
+  }
+  for (var i = 0; i < labels.length; i++) {
+    this.setIndexByName_[labels[i]] = i;
   }
 
   this.computeYAxisRanges_(extremes);


### PR DESCRIPTION
Calling `indexFromSetName` on the last set would fail if its visibility was set to false, because the set's label would not be added to the internal list of sets (stored in the `setIndexByName_` variable).

This pull request fixes the issue, and adds a test to check that it works.

The test added to `tests/data_api.js` provides an example that currently fails, and now passes with this fix.