### PR TITLE
Check that setRow is not negative, fixes #644.

### DIFF
--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1813,7 +1813,7 @@ Dygraph.prototype.setSelection = function(row, opt_seriesName, opt_locked) {
       // for.  If it is, just use it, otherwise search the array for a point
       // in the proper place.
       var setRow = row - this.getLeftBoundary_(setIdx);
-      if (setRow < points.length && points[setRow].idx == row) {
+      if (setRow >= 0 && setRow < points.length && points[setRow].idx == row) {
         var point = points[setRow];
         if (point.yval !== null) this.selPoints_.push(point);
       } else {


### PR DESCRIPTION
Synchronization breaks up if this case is not checked. Fix has been
proposed in the bugreport.