### PR TITLE
Dygraph.dateString_: shows milliseconds if any.

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -6,6 +6,10 @@ This is a step-by-step guide explaining how to do it.
 
 ### How-to
 
+To install dependencies, run
+
+    npm install
+
 To build dygraphs, run
 
     npm run build

--- a/auto_tests/tests/date_formats.js
+++ b/auto_tests/tests/date_formats.js
@@ -36,4 +36,12 @@ it('testHyphenatedDate', function() {
   assert.equal(Date.UTC(2000, 1, 2), utils.dateParser(str));
 });
 
+it('testMillisecondsDate', function() {
+  // Format: YYYY-MM-DD HH:MM:SS.MS
+
+  // Midnight February 2, 2000 14:25:42.123 UTC
+  var ts = Date.UTC(2000, 1, 2, 14, 25, 42, 123);
+  assert.equal("2000/02/02 14:25:42.123", utils.dateString_(ts, true));
+});
+
 });

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -397,7 +397,7 @@ export function dateString_(time, utc) {
   var month = zeropad(m + 1);  //months are 0-offset, sigh
   // Get a 0 padded day string
   var day = zeropad(d);
-  var frac = hh * 3600 + mm * 60 + ss;
+  var frac = hh * 3600 + mm * 60 + ss + 1e-3 * ms;
   var ret = year + "/" + month + "/" + day;
   if (frac) {
     ret += " " + hmsString_(hh, mm, ss, ms);

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -1230,7 +1230,7 @@ export function dateAxisLabelFormatter(date, granularity, opts) {
       // e.g. '21 Jan' (%d%b)
       return zeropad(day) + '&#160;' + SHORT_MONTH_NAMES_[month];
     } else {
-      return hmsString_(hours, mins, secs);
+      return hmsString_(hours, mins, secs, millis);
     }
   }
 };

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -1217,7 +1217,7 @@ export function dateAxisLabelFormatter(date, granularity, opts) {
       hours = accessors.getHours(date),
       mins = accessors.getMinutes(date),
       secs = accessors.getSeconds(date),
-      millis = accessors.getSeconds(date);
+      millis = accessors.getMilliseconds(date);
 
   if (granularity >= DygraphTickers.Granularity.DECADAL) {
     return '' + year;

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -367,7 +367,8 @@ export function hmsString_(hh, mm, ss, ms) {
   if (ss) {
     ret += ":" + zeropad(ss);
     if (ms) {
-      ret += "." + ms;
+      var str = "" + ms;
+      ret += "." + ('000'+str).substring(str.length);
     }
   }
   return ret;

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -367,7 +367,7 @@ export function hmsString_(hh, mm, ss, ms) {
   if (ss) {
     ret += ":" + zeropad(ss);
     if (ms) {
-      ret += ":" + zeropad(ms);
+      ret += "." + ms;
     }
   }
   return ret;

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -362,10 +362,13 @@ export var DateAccessorsUTC = {
  * @return {string} A time of the form "HH:MM" or "HH:MM:SS"
  * @private
  */
-export function hmsString_(hh, mm, ss) {
+export function hmsString_(hh, mm, ss, ms) {
   var ret = zeropad(hh) + ":" + zeropad(mm);
   if (ss) {
     ret += ":" + zeropad(ss);
+    if (ms) {
+      ret += ":" + zeropad(ms);
+    }
   }
   return ret;
 };
@@ -387,6 +390,7 @@ export function dateString_(time, utc) {
   var hh = accessors.getHours(date);
   var mm = accessors.getMinutes(date);
   var ss = accessors.getSeconds(date);
+  var ms = accessors.getMilliseconds(date);
   // Get a year string:
   var year = "" + y;
   // Get a 0 padded month string
@@ -396,7 +400,7 @@ export function dateString_(time, utc) {
   var frac = hh * 3600 + mm * 60 + ss;
   var ret = year + "/" + month + "/" + day;
   if (frac) {
-    ret += " " + hmsString_(hh, mm, ss);
+    ret += " " + hmsString_(hh, mm, ss, ms);
   }
   return ret;
 };

--- a/tests/labelsDateMilliseconds.html
+++ b/tests/labelsDateMilliseconds.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>UTC date labels</title>
+    <!--
+    For production (minified) code, use:
+    <script type="text/javascript" src="dygraph-combined.js"></script>
+    -->
+    <script type="text/javascript" src="../dist/dygraph.js"></script>
+  </head>
+  <body>
+
+    <h2>Milliseconds display in date and time labels</h2>
+
+    <p>This shows how milliseconds are displayed when present.</p>
+
+    <div id="div_loc" style="width:600px; height:200px;"></div>
+    <div id="div_utc" style="width:600px; height:200px;"></div>
+    
+    <p>You can check it by hovering over corresponding points and comparing
+    the value labels.</p>
+
+    <script type="text/javascript">
+      var values = (function () {
+        var rand10 = function () { return Math.round(10 * Math.random()); };
+        var a = [];
+        for (var n=0; n < 72; n++) {
+          a.push(rand10());
+        }
+        return a;
+      })();
+      function data(y,m,d,hh,mm,ss,ms) {
+        var a = [];
+        for (var n=0; n < 72; n++) {
+          a.push([new Date(Date.UTC(y, m, d, hh + n, mm, ss, ms)), values[n]]);
+        }
+        return a;
+      }
+      gloc = new Dygraph(
+                   document.getElementById("div_loc"),
+                   data(2009, 6, 25, 14, 34, 56, 654),
+                   {
+                     labels: ['time with ms', 'random']
+                   }
+                 );
+      gutc = new Dygraph(
+                   document.getElementById("div_utc"),
+                   data(2009, 6, 25, 14, 0, 0, 0),
+                   {
+                     labels: ['time', 'random']
+                   }
+                 );
+    </script>
+
+  </body>
+</html>

--- a/tests/labelsDateMilliseconds.html
+++ b/tests/labelsDateMilliseconds.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>UTC date labels</title>
+    <title>Milliseconds date labels</title>
     <!--
     For production (minified) code, use:
     <script type="text/javascript" src="dygraph-combined.js"></script>
@@ -14,8 +14,8 @@
 
     <p>This shows how milliseconds are displayed when present.</p>
 
-    <div id="div_loc" style="width:600px; height:200px;"></div>
-    <div id="div_utc" style="width:600px; height:200px;"></div>
+    <div id="div_ms" style="width:600px; height:200px;"></div>
+    <div id="div_std" style="width:600px; height:200px;"></div>
     
     <p>You can check it by hovering over corresponding points and comparing
     the value labels.</p>
@@ -36,15 +36,15 @@
         }
         return a;
       }
-      gloc = new Dygraph(
-                   document.getElementById("div_loc"),
+      gms = new Dygraph(
+                   document.getElementById("div_ms"),
                    data(2009, 6, 25, 14, 34, 56, 654),
                    {
                      labels: ['time with ms', 'random']
                    }
                  );
-      gutc = new Dygraph(
-                   document.getElementById("div_utc"),
+      gstd = new Dygraph(
+                   document.getElementById("div_std"),
                    data(2009, 6, 25, 14, 0, 0, 0),
                    {
                      labels: ['time', 'random']


### PR DESCRIPTION
1st commit add a feature to Dygraph.dateString_: shows milliseconds if any.
2nd commit fixes a typo in dateAxisLabelFormatter.