### PR TITLE
Make old-style per-series options throw

### DIFF
--- a/src/dygraph-options.js
+++ b/src/dygraph-options.js
@@ -384,8 +384,8 @@ DygraphOptions.prototype.warnInvalidOption_ = function(optionName) {
       console.warn('Use new-style per-series options (saw ' + optionName + ' as top-level options key). See http://bit.ly/1tceaJs');
     } else {
       console.warn('Unknown option ' + optionName + ' (full list of options at dygraphs.com/options.html');
-      throw "invalid option " + optionName;
     }
+    throw "invalid option " + optionName;
   }
 };
 


### PR DESCRIPTION
Closes #675 

These have been deprecated for 4+ years, so everyone's had a chance to see the warning.