### PR TITLE
Only include visible series in range selector

### DIFF
--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -789,7 +789,7 @@ OPTIONS_REFERENCE =  // <JSON>
     "default": "null",
     "labels": ["Range Selector"],
     "type": "boolean",
-    "description": "Mark this series for inclusion in the range selector. The mini plot curve will be an average of all such series. If this is not specified for any series, the default behavior is to average all the series. Setting it for one series will result in that series being charted alone in the range selector."
+    "description": "Mark this series for inclusion in the range selector. The mini plot curve will be an average of all such series. If this is not specified for any series, the default behavior is to average all the visible series. Setting it for one series will result in that series being charted alone in the range selector. Once it's set for a single series, it needs to be set for all series which should be included (regardless of visibility)."
   },
   "animatedZooms": {
     "default": "false",

--- a/src/plugins/range-selector.js
+++ b/src/plugins/range-selector.js
@@ -635,13 +635,23 @@ rangeSelector.prototype.computeCombinedSeriesAndLimits_ = function() {
   var labels = g.getLabels();
   var includeSeries = new Array(numColumns);
   var anySet = false;
+  var visibility = g.visibility();
+  var inclusion = [];
+
   for (i = 1; i < numColumns; i++) {
     var include = this.getOption_('showInRangeSelector', labels[i]);
-    includeSeries[i] = include;
+    inclusion.push(include);
     if (include !== null) anySet = true;  // it's set explicitly for this series
   }
-  if (!anySet) {
-    for (i = 0; i < includeSeries.length; i++) includeSeries[i] = true;
+
+  if (anySet) {
+    for (i = 1; i < numColumns; i++) {
+      includeSeries[i] = inclusion[i - 1];
+    }
+  } else {
+    for (i = 1; i < numColumns; i++) {
+      includeSeries[i] = visibility[i - 1];
+    }
   }
 
   // Create a combined series (average of selected series values).


### PR DESCRIPTION
Closes #429

I don't love the interaction with `showInRangeSelector`, but I don't see a better way to handle it. Once you set `showInRangeSelector` on any series, you're managing this manually. Regardless of visibility.