### PR TITLE
Explicitly cast data value prior to finding extremes

### DIFF
--- a/src/datahandler/default.js
+++ b/src/datahandler/default.js
@@ -83,7 +83,7 @@ DefaultHandler.prototype.getExtremeYValues = function(series, dateWindow,
   var firstIdx = 0, lastIdx = series.length - 1;
 
   for ( var j = firstIdx; j <= lastIdx; j++) {
-    y = series[j][1];
+    y = new Number(series[j][1]);
     if (y === null || isNaN(y))
       continue;
     if (maxY === null || y > maxY) {


### PR DESCRIPTION
Solves some edge-case incorrect Y-axis zooming, resultant from supplying a data series containing mixed value types.  For example, some servers supply datasets comprising a mixture of: strings for floating point values with a large number of digits, integers, strings for integers, and regular floating point types.  This kind of issue can be difficult to detect, as dygraphs code involving the manipulation of the data values can appear to work correctly without throwing errors.  Within the getExtremeYValues prototype, an operation is performed that compares the values.  Therefore dygraph should be certain it is comparing values of equal types prior to making the comparison.

(This would be much more efficient to do once, when the data is first presented to dygraph, but I'm not sure of the correct location.)
