### PR TITLE
Fix bug when resize event is triggered before data are ready

### DIFF
--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1996,6 +1996,9 @@ Dygraph.prototype.getHandlerClass_ = function() {
  * number of axes, rolling averages, etc.
  */
 Dygraph.prototype.predraw_ = function() {
+  if (!this.rawData_) {
+    return;
+  }
   var start = new Date();
 
   // Create the correct dataHandler


### PR DESCRIPTION
When using twitter bootstrap tab component and Dygraph error occurs when the user goes to a tab before the data are ready.

It occurs because resize event is triggered in some framework (like the one I used at the office) when user goes to another tab.

This small check prevent Dygraph to crash when user goes to a Tab and data are not ready