### PR TITLE
Per series roll period

### DIFF
--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -2026,14 +2026,23 @@ Dygraph.prototype.predraw_ = function() {
 
   this.cascadeEvents_('predraw');
 
+  var seriesName = this.getLabels();
+
   // Convert the raw data (a 2D array) into the internal format and compute
   // rolling averages.
   this.rolledSeries_ = [null];  // x-axis is the first series and it's special
   for (var i = 1; i < this.numColumns(); i++) {
     // var logScale = this.attr_('logscale', i); // TODO(klausw): this looks wrong // konigsberg thinks so too.
     var series = this.dataHandler_.extractSeries(this.rawData_, i, this.attributes_);
-    if (this.rollPeriod_ > 1) {
-      series = this.dataHandler_.rollingAverage(series, this.rollPeriod_, this.attributes_);
+	var seriesRollPeriod;
+	
+	if (this.getOption("rollPeriod", seriesName[i]) == undefined) { 
+		seriesRollPeriod = this.rollPeriod(); 
+	} else {
+		seriesRollPeriod = this.getOption("rollPeriod", seriesName[i]);
+	}
+    if (seriesRollPeriod > 1) {
+      series = this.dataHandler_.rollingAverage(series, seriesRollPeriod, this.attributes_);
     }
 
     this.rolledSeries_.push(series);


### PR DESCRIPTION
Enables adding of rollPeriod inside series parameters. If rollPeriod is
set globally, series will default to that if parameter not set

Please read the guide to making dygraphs changes:
http://dygraphs.com/changes.html

Pull Requests will only be accepted if:

- You clearly explain what you're adding and why you believe it's an
  improvement. For example: "Fixes issue #123".
- You adhere to the style of the rest of the dygraphs code base.
- You write an `auto_test` for the code that you're adding.

Be sure to document any new options you add. Also be aware that PRs which add
options are likely to be rejected. dygraphs already has many options. If you
can fit your feature into one of those or implement it as a plugin, it will be
more likely to get merged.
