### PR TITLE
Fix gallery navigation from interaction demo

### DIFF
--- a/gallery/interaction.js
+++ b/gallery/interaction.js
@@ -49,9 +49,6 @@ Gallery.register(
 
     },
     run: function() {
-      var lastClickedGraph;
-      document.addEventListener("mousewheel", function() { lastClickedGraph = null; });
-      document.addEventListener("click", function() { lastClickedGraph = null; });
       new Dygraph(document.getElementById("div_g"),
            NoisyData, { errorBars : true });
       new Dygraph(document.getElementById("div_g2"),
@@ -84,9 +81,5 @@ Gallery.register(
              },
              underlayCallback : captureCanvas
           });
-    },
-    clean: function() {
-      document.removeEventListener('mousewheel');
-      document.removeEventListener('click');
     }
   });


### PR DESCRIPTION
Demo named "Custom interaction models" in Dygraphs Gallery breaks further navigation in the gallery. When a user reached the interaction demo it was not possible to navigate away from it anymore.