### PR TITLE
spelling fixes

### DIFF
--- a/docs/site.css
+++ b/docs/site.css
@@ -32,7 +32,7 @@ body {
   }
 }
 @media screen and (min-width: 768px) and (max-width: 992px) {
-  /* The topnav drops down to the next line between these sizes. We must accomodate. */
+  /* The topnav drops down to the next line between these sizes. We must accommodate. */
   body {
     padding-top: 130px;
   }

--- a/docs/ssi_server.py
+++ b/docs/ssi_server.py
@@ -9,7 +9,7 @@ inline SSI (Server Side Includes) of the form:
 
   <!-- #include virtual="fragment.html" -->
 
-Run ./ssi_server.py in this directory and visit localhost:8000 for an exmaple.
+Run ./ssi_server.py in this directory and visit localhost:8000 for an example.
 '''
 
 import os

--- a/gallery/number-format.js
+++ b/gallery/number-format.js
@@ -5,7 +5,7 @@ Gallery.register(
     name: 'Number formatting',
     setup: function(parent) {
       parent.innerHTML = 
-          "<p>The default formatting mimicks printf with %.<i>p</i>g where <i>p</i> is" +
+          "<p>The default formatting mimics printf with %.<i>p</i>g where <i>p</i> is" +
           "   the precision to use.  It turns out that JavaScript's toPrecision()" +
           "   method is almost but not exactly equal to %g; they differ for values" +
           "   with small absolute values (10^-1 to 10^-5 or so), with toPrecision()" +

--- a/scripts/check-no-only.sh
+++ b/scripts/check-no-only.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Checks that no ".only" has made it into tests. This should never be commited,
+# Checks that no ".only" has made it into tests. This should never be committed,
 # since it will disable the vast majority of tests.
 
 if grep -R '\.only(' auto_tests/tests; then

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -586,7 +586,7 @@ OPTIONS_REFERENCE =  // <JSON>
     "default": "null",
     "labels": ["Axis display", "Interactive Elements"],
     "type": "float",
-    "description": "A value representing the farthest a graph may be panned, in percent of the display. For example, a value of 0.1 means that the graph can only be panned 10% pased the edges of the displayed values. null means no bounds."
+    "description": "A value representing the farthest a graph may be panned, in percent of the display. For example, a value of 0.1 means that the graph can only be panned 10% passed the edges of the displayed values. null means no bounds."
   },
   "title": {
     "labels": ["Chart labels"],

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -42,7 +42,7 @@ export var logRangeFraction = function(r0, r1, pct) {
   // Original calcuation:
   // pct = (log(x) - log(xRange[0])) / (log(xRange[1]) - log(xRange[0])));
   //
-  // Multiply both sides by the right-side demoninator.
+  // Multiply both sides by the right-side denominator.
   // pct * (log(xRange[1] - log(xRange[0]))) = log(x) - log(xRange[0])
   //
   // add log(xRange[0]) to both sides
@@ -265,7 +265,7 @@ export function isValidPoint(p, opt_allowNaNY) {
 };
 
 /**
- * Number formatting function which mimicks the behavior of %g in printf, i.e.
+ * Number formatting function which mimics the behavior of %g in printf, i.e.
  * either exponential or fixed format (without trailing 0s) is used depending on
  * the length of the generated string.  The advantage of this format is that
  * there is a predictable upper bound on the resulting string length,
@@ -377,7 +377,7 @@ export function hmsString_(hh, mm, ss, ms) {
 /**
  * Convert a JS date (millis since epoch) to a formatted string.
  * @param {number} time The JavaScript time value (ms since epoch)
- * @param {boolean} utc Wether output UTC or local time
+ * @param {boolean} utc Whether output UTC or local time
  * @return {string} A date of one of these forms:
  *     "YYYY/MM/DD", "YYYY/MM/DD HH:MM" or "YYYY/MM/DD HH:MM:SS"
  * @private

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -3126,7 +3126,7 @@ Dygraph.prototype.updateOptions = function(input_attrs, block_redraw) {
 
   if (file) {
     // This event indicates that the data is about to change, but hasn't yet.
-    // TODO(danvk): support cancelation of the update via this event.
+    // TODO(danvk): support cancellation of the update via this event.
     this.cascadeEvents_('dataWillUpdate', {});
 
     this.file_ = file;

--- a/tests/number-format.html
+++ b/tests/number-format.html
@@ -7,7 +7,7 @@
 
   </head>
   <body>
-    <p>The default formatting mimicks printf with %.<i>p</i>g where <i>p</i> is
+    <p>The default formatting mimics printf with %.<i>p</i>g where <i>p</i> is
        the precision to use.  It turns out that JavaScript's toPrecision()
        method is almost but not exactly equal to %g; they differ for values
        with small absolute values (10^-1 to 10^-5 or so), with toPrecision()


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.

