### PR TITLE
Add option to color the range selector's veil

### DIFF
--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -780,6 +780,12 @@ OPTIONS_REFERENCE =  // <JSON>
     "type": "boolean",
     "description": "Mark this series for inclusion in the range selector. The mini plot curve will be an average of all such series. If this is not specified for any series, the default behavior is to average all the visible series. Setting it for one series will result in that series being charted alone in the range selector. Once it's set for a single series, it needs to be set for all series which should be included (regardless of visibility)."
   },
+  "rangeSelectorForegroundFillColor": {
+    "default": "null",
+    "labels": ["Range Selector"],
+    "type": "string",
+    "description": "The color of the veil of the range selector"
+  },
   "animatedZooms": {
     "default": "false",
     "labels": ["Interactive Elements"],

--- a/src/plugins/range-selector.js
+++ b/src/plugins/range-selector.js
@@ -752,6 +752,7 @@ rangeSelector.prototype.drawInteractiveLayer_ = function() {
   var width = this.canvasRect_.w - margin;
   var height = this.canvasRect_.h - margin;
   var zoomHandleStatus = this.getZoomHandleStatus_();
+  var fillStyle = this.getOption_('rangeSelectorForegroundFillColor');
 
   ctx.strokeStyle = this.getOption_('rangeSelectorForegroundStrokeColor');
   ctx.lineWidth = this.getOption_('rangeSelectorForegroundLineWidth');
@@ -766,7 +767,11 @@ rangeSelector.prototype.drawInteractiveLayer_ = function() {
     var leftHandleCanvasPos = Math.max(margin, zoomHandleStatus.leftHandlePos - this.canvasRect_.x);
     var rightHandleCanvasPos = Math.min(width, zoomHandleStatus.rightHandlePos - this.canvasRect_.x);
 
-    ctx.fillStyle = 'rgba(240, 240, 240, ' + this.getOption_('rangeSelectorAlpha').toString() + ')';
+    if (fillStyle) {
+      ctx.fillStyle = fillStyle
+    } else {
+      ctx.fillStyle = 'rgba(240, 240, 240, ' + this.getOption_('rangeSelectorAlpha').toString() + ')';
+    }
     ctx.fillRect(0, 0, leftHandleCanvasPos, this.canvasRect_.h);
     ctx.fillRect(rightHandleCanvasPos, 0, this.canvasRect_.w - rightHandleCanvasPos, this.canvasRect_.h);
 

--- a/tests/range-selector.html
+++ b/tests/range-selector.html
@@ -64,6 +64,11 @@
     <p>Demo of range selector with stepPlot</p>
     <div id="stepplot" style="width:800px; height:320px;"></div>
 
+    <div id="rangeselectorveil" style="width:800px; height:320px;"></div>
+    <p>
+      Demo of setting a custom color for the range selector veil.
+    </p>
+
     <script type="text/javascript">
       g1 = new Dygraph(
           document.getElementById("noroll"),
@@ -180,6 +185,22 @@
                           includeZero: true,
                           showRangeSelector: true
                        });
+      g8 = new Dygraph(
+          document.getElementById("rangeselectorveil"),
+          [
+            [0, 4],
+            [10, 2],
+            [25, 15],
+            [35, 8],
+            [42, 9]
+          ],
+          {
+            title: 'Daily Temperatures in New York vs. San Francisco',
+            ylabel: 'Temperature (F)',
+            showRangeSelector: true,
+            rangeSelectorForegroundFillColor: 'rgba(200,0,40,0.6)',
+            dateWindow: [5, 20],
+          }); 
     </script>
   </body>
 </html>


### PR DESCRIPTION
Add the option 'rangeSelectorForegroundFillColor' to customize the color of the range selector's veil.