### PR TITLE
Fix two inconsistencies in dygraph-externs.js

### DIFF
--- a/dygraph-externs.js
+++ b/dygraph-externs.js
@@ -40,7 +40,7 @@ Dygraph.prototype.isZoomed;
 /** @type {function(): string} */
 Dygraph.prototype.toString;
 
-/** @type {function(string, string)} */
+/** @type {function(string, string=)} */
 Dygraph.prototype.getOption;
 
 /** @type {function(): number} */
@@ -127,7 +127,7 @@ Dygraph.prototype.isSeriesLocked;
 /** @type {function(): number} */
 Dygraph.prototype.numAxes;
 
-/** @type {function(Object, Boolean=)} */
+/** @type {function(Object, boolean=)} */
 Dygraph.prototype.updateOptions;
 
 /** @type {function(number, number)} */


### PR DESCRIPTION
1. The second argument of getOption should be marked as optional per
jsdoc at: http://dygraphs.com/jsdoc/symbols/Dygraph.html#getOption

2. 'boolean' is typo'd as 'Boolean' in updateOptions.