### PR TITLE
Adding a new option to make the y-axis fixed.

### DIFF
--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -804,6 +804,12 @@ OPTIONS_REFERENCE =  // <JSON>
     "type": "Object",
     "description": "Defines per-axis options. Valid keys are 'x', 'y' and 'y2'. Only some options may be set on a per-axis basis. If an option may be set in this way, it will be noted on this page. See also documentation on <a href='http://dygraphs.com/per-axis.html'>per-series and per-axis options</a>."
   },
+  "fixedyAxis": {
+    "default": "false",
+    "labels": ["Configuration"],
+    "type": "boolean",
+    "description": "Setting this option to true reverts the zoomout y-axis behavior to Dygraphs 1.x, making the y-axis fixed if set and not reset after zoomouts."
+  },
   "series": {
     "default": "null",
     "labels": ["Series"],

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1350,14 +1350,18 @@ Dygraph.prototype.resetZoom = function() {
 
   const animatedZooms = this.getBooleanOption('animatedZooms');
   const zoomCallback = this.getFunctionOption('zoomCallback');
+  const fixedyAxis = this.getBooleanOption('fixedyAxis');
 
   // TODO(danvk): merge this block w/ the code below.
   // TODO(danvk): factor out a generic, public zoomTo method.
   if (!animatedZooms) {
     this.dateWindow_ = null;
-    this.axes_.forEach(axis => {
-      if (axis.valueRange) delete axis.valueRange;
-    });
+    if (!fixedyAxis) {
+      this.axes_.forEach(axis => {
+        if (axis.valueRange) delete axis.valueRange;
+      });
+    }
+
 
     this.drawGraph_();
     if (zoomCallback) {
@@ -1374,15 +1378,21 @@ Dygraph.prototype.resetZoom = function() {
 
   if (dirtyY) {
     oldValueRanges = this.yAxisRanges();
-    newValueRanges = this.yAxisExtremes();
+    newValueRanges = oldValueRanges
+
+    if (!fixedyAxis) {
+      newValueRanges = this.yAxisExtremes();
+    }
   }
 
   this.doAnimatedZoom(oldWindow, newWindow, oldValueRanges, newValueRanges,
       () => {
         this.dateWindow_ = null;
-        this.axes_.forEach(axis => {
-          if (axis.valueRange) delete axis.valueRange;
-        });
+        if (!fixedyAxis) {
+          this.axes_.forEach(axis => {
+            if (axis.valueRange) delete axis.valueRange;
+          });
+        }
         if (zoomCallback) {
           zoomCallback.call(this, minDate, maxDate, this.yAxisRanges());
         }


### PR DESCRIPTION
While I do realize this is unlikely to be accepted, I'd like to bring up this discussion and maybe someone proposes a better solution.

On Dygraphs 1.x, when you zoomed out the graph with a double click, the y-axis was preserved. On Dygraphs 2.x, the y-axis automatically set based on the data. There's an example about this here:

https://github.com/danvk/dygraphs/blob/aa0b189f8cb22d64ce65cc9b205c90f6e4fd1257/tests/old-yrange-behavior.html

The same example also shows how you can get around the new behavior using a plugin for the double-click event. However, when using the `rangeSelector` plugin, there doesn't seem to be an easy way around this.

It should be possible to restore the `valueRange` property on the predraw event, however, since using `updateOptions` triggers a redraw, it has to be done without it, thus becoming error-prone. However, after further investigation, I couldn't find a way to do this with `animatedZooms: true`, since the animation is calculated using `newValueRanges = this.yAxisExtremes();`.

Finally. I also think this behavior is undesired if a `valueRange` was explicitly set. Dygraphs doesn't offer a way to change the y-axis by default, so it's impossible to restore the initial graph state without resorting to custom code. which I find very counter-intuitive.

I did not write an auto_test for this, but am willing to if this PR is to be accepted in its current form, or any form that leads to a solution to the problem.

Feedback is appreciated. Thanks for your hard work. 
