### PR TITLE
fixes issue #781

### DIFF
--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -2539,8 +2539,13 @@ Dygraph.prototype.computeYAxisRanges_ = function(extremes) {
 
       // special case #781: if we have no sense of scale, center on the sole value.
       if (y0 === y1) {
-          y0 -= 0.5;
-          y1 += 0.5;
+        if(y0 === 0) {
+          y1 = 1;
+        } else {
+          var delta = Math.abs(y0 / 10);
+          y0 -= delta;
+          y1 += delta;
+        }
       }
 
       if (logscale) {

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -2533,16 +2533,22 @@ Dygraph.prototype.computeYAxisRanges_ = function(extremes) {
     if (!ypadCompat) {
       // When using yRangePad, adjust the upper/lower bounds to add
       // padding unless the user has zoomed/panned the Y axis range.
+
+      y0 = axis.computedValueRange[0];
+      y1 = axis.computedValueRange[1];
+
+      // special case #781: if we have no sense of scale, center on the sole value.
+      if (y0 === y1) {
+          y0 -= 0.5;
+          y1 += 0.5;
+      }
+
       if (logscale) {
-        y0 = axis.computedValueRange[0];
-        y1 = axis.computedValueRange[1];
         var y0pct = ypad / (2 * ypad - 1);
         var y1pct = (ypad - 1) / (2 * ypad - 1);
         axis.computedValueRange[0] = utils.logRangeFraction(y0, y1, y0pct);
         axis.computedValueRange[1] = utils.logRangeFraction(y0, y1, y1pct);
       } else {
-        y0 = axis.computedValueRange[0];
-        y1 = axis.computedValueRange[1];
         span = y1 - y0;
         axis.computedValueRange[0] = y0 - span * ypad;
         axis.computedValueRange[1] = y1 + span * ypad;


### PR DESCRIPTION
As described in #781, the library makes wrong decisions when the y-range is zero.
In such cases (`y0 === y1`), this PR changes:

```js
y0 -= 0.5
y1 += 0.5
```

so that the chart is properly rendered.
