### PR TITLE
Support select by nearest point to mouse

### DIFF
--- a/auto_tests/tests/select_mode.js
+++ b/auto_tests/tests/select_mode.js
@@ -1,0 +1,1456 @@
+/**
+ * @fileoverview Tests involving issuing XHRs for data.
+ *
+ * Note that these tests must be run with an HTTP server.
+ * XHRs can't be issued from file:/// URLs.
+ * This can be done with
+ *
+ *     npm install http-server
+ *     http-server
+ *     open http://localhost:8080/auto_tests/runner.html
+ *
+ */
+
+import Dygraph from '../../src/dygraph';
+import DygraphOps from './DygraphOps';
+import Util from './Util';
+
+import 'core-js/es6/promise';
+
+// Note that this data contains 2 points with the same
+// x value. euclidian selection mode can distinguish them.
+var TEST_SERIES = "X,Y1,Y2\n" +
+                  "0,1,3\n" +
+                  "0.5,1,3\n" +
+                  "0.7,4.5,2.5\n" +
+                  "0.7,5,3\n" +
+                  "1,1,4\n";
+
+// A version without the duplicate x value, for use with
+// stacked graphs (these don't show duplicate x values).
+var TEST_SERIES_NODUP = "X,Y1,Y2\n" +
+                  "0,1,3\n" +
+                  "0.5,1,3\n" +
+                  "0.7,4.5,2.5\n" +
+                  "1,1,4\n";
+
+
+
+function lockSeries(graph) {
+  graph.setSelection(4, 'Y1', true);
+}
+
+function makeGraph(series, options) {
+  return new Dygraph(
+      document.getElementById('graph'),
+      series,
+      options
+  );
+}
+
+describe("select-mode", function() {
+
+cleanupAfterEach();
+
+/**
+ * Default behaviour:
+ *
+ * selectMode: closest-x
+ * highlightSeriesOpts: no
+ * stacked: no
+ * series locked: no
+ */
+it('default-settings', () => {
+
+  var g = makeGraph(TEST_SERIES, null);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(4, g.getSelection());
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+
+});
+
+/**
+ * Explicitly set closest-x
+ *
+ * selectMode: closest-x
+ * highlightSeriesOpts: no
+ * stacked: no
+ * series locked: no
+ */
+it('closest-x/no highlight/not stacked/no series lock', () => {
+
+  var g = makeGraph(TEST_SERIES, {
+    selectMode: 'closest-x'
+  });
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(4, g.getSelection());
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+
+});
+
+/**
+ * selectMode: euclidian
+ * highlightSeriesOpts: no
+ * stacked: no
+ * series locked: no
+ */
+it('euclidian/no highlight/not stacked/no series lock', () => {
+
+  var g = makeGraph(TEST_SERIES, {
+    selectMode: 'euclidian'
+  });
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(4, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(4, g.getSelection());
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+
+});
+
+/**
+ * Should behave like euclidian 
+ *
+ * selectMode: closest-x
+ * highlightSeriesOpts: yes
+ * stacked: no
+ * series locked: no
+ */
+it('closest-x/with highlight/not stacked/no series lock', () => {
+
+  var g = makeGraph(TEST_SERIES, {
+    selectMode: 'closest-x',
+    highlightSeriesOpts: {strokeWidth: 2}
+  });
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+});
+
+
+/**
+ * selectMode: euclidian
+ * highlightSeriesOpts: yes
+ * stacked: no
+ * series locked: no
+ */
+it('euclidian/with highlight/not stacked/no series lock', () => {
+
+  var g = makeGraph(TEST_SERIES, {
+    selectMode: 'euclidian',
+    highlightSeriesOpts: {strokeWidth: 2}
+  });
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+});
+
+/**
+ * selectMode: closest-x
+ * highlightSeriesOpts: no
+ * stacked: yes
+ * series locked: no
+ */
+it('closest-x/no highlight/is stacked/no series lock', () => {
+
+  var g = makeGraph(TEST_SERIES_NODUP, {
+    selectMode: 'closest-x',
+    stackedGraph: true
+  });
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(3, g.getSelection());
+
+  // Mouse along y=7
+  DygraphOps.dispatchMouseMove(g, 0, 7);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 7);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 7);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 7);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 7);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 7);
+  assert.equal(3, g.getSelection());
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+
+});
+
+/**
+ * selectMode: euclidian
+ * highlightSeriesOpts: no
+ * stacked: yes
+ * series locked: no
+ */
+it('euclidian/no highlight/is stacked/no series lock', () => {
+
+  var g = makeGraph(TEST_SERIES_NODUP, {
+    selectMode: 'euclidian',
+    stackedGraph: true
+  });
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(3, g.getSelection());
+
+  // Mouse along y=7
+  DygraphOps.dispatchMouseMove(g, 0, 7);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 7);
+  assert.equal(0, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 7);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 7);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 7);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 1, 7);
+  assert.equal(3, g.getSelection());
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+});
+
+/**
+ * selectMode: closest-x
+ * highlightSeriesOpts: yes
+ * stacked: yes
+ * series locked: no
+ */
+it('closest-x/with highlight/is stacked/no series lock', () => {
+
+  var g = makeGraph(TEST_SERIES_NODUP, {
+    selectMode: 'closest-x',
+    stackedGraph: true,
+    highlightSeriesOpts: {strokeWidth: 2}
+  });
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  // Mouse along y=7
+  DygraphOps.dispatchMouseMove(g, 0, 7);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 7);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 7);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 7);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 7);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 7);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: euclidian
+ * highlightSeriesOpts: yes
+ * stacked: yes
+ * series locked: no
+ */
+it('euclidian/with highlight/is stacked/no series lock', () => {
+
+  var g = makeGraph(TEST_SERIES_NODUP, {
+    selectMode: 'euclidian',
+    stackedGraph: true,
+    highlightSeriesOpts: {strokeWidth: 2}
+  });
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  // Mouse along y=7
+  DygraphOps.dispatchMouseMove(g, 0, 7);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 7);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 7);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 7);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 7);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 7);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y2', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: closest-x
+ * highlightSeriesOpts: no
+ * stacked: no
+ * series locked: yes
+ */
+it('closest-x/no highlight/not stacked/with series lock', () => {
+
+  var g = makeGraph(TEST_SERIES, {
+    selectMode: 'closest-x',
+  });
+
+  // Lock the series
+  g.setSelection(0, 'Y1', true);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: euclidian
+ * highlightSeriesOpts: no
+ * stacked: no
+ * series locked: yes
+ */
+it('euclidian/no highlight/not stacked/with series lock', () => {
+
+  var g = makeGraph(TEST_SERIES, {
+    selectMode: 'euclidian',
+  });
+
+  // Lock the series
+  g.setSelection(0, 'Y1', true);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: closest-x
+ * highlightSeriesOpts: yes
+ * stacked: no
+ * series locked: yes
+ */
+it('closest-x/with highlight/not stacked/with series lock', () => {
+
+  var g = makeGraph(TEST_SERIES, {
+    selectMode: 'closest-x',
+    highlightSeriesOpts: {strokeWidth: 2}
+  });
+
+  // Lock the series
+  g.setSelection(0, 'Y1', true);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: euclidian
+ * highlightSeriesOpts: yes
+ * stacked: no
+ * series locked: yes
+ */
+it('euclidian/with highlight/not stacked/with series lock', () => {
+
+  var g = makeGraph(TEST_SERIES, {
+    selectMode: 'euclidian',
+    highlightSeriesOpts: {strokeWidth: 2}
+  });
+
+  // Lock the series
+  g.setSelection(0, 'Y1', true);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(4, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: closest-x
+ * highlightSeriesOpts: no
+ * stacked: yes
+ * series locked: yes
+ */
+it('closest-x/no highlight/is stacked/with series lock', () => {
+
+  var g = makeGraph(TEST_SERIES_NODUP, {
+    selectMode: 'closest-x',
+    stackedGraph: true
+  });
+
+  // Lock the series
+  g.setSelection(0, 'Y1', true);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: euclidian
+ * highlightSeriesOpts: no
+ * stacked: yes
+ * series locked: yes
+ */
+it('euclidian/no highlight/is stacked/with series lock', () => {
+
+  var g = makeGraph(TEST_SERIES_NODUP, {
+    selectMode: 'euclidian',
+    stackedGraph: true
+  });
+
+  // Lock the series
+  g.setSelection(0, 'Y1', true);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: closest-x
+ * highlightSeriesOpts: yes
+ * stacked: yes
+ * series locked: yes
+ */
+it('closest-x/with highlight/is stacked/with series lock', () => {
+
+  var g = makeGraph(TEST_SERIES_NODUP, {
+    selectMode: 'closest-x',
+    stackedGraph: true,
+    highlightSeriesOpts: {strokeWidth: 2}
+  });
+
+  // Lock the series
+  g.setSelection(0, 'Y1', true);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+});
+
+/**
+ * selectMode: euclidian
+ * highlightSeriesOpts: yes
+ * stacked: yes
+ * series locked: yes
+ */
+it('euclidian/with highlight/is stacked/with series lock', () => {
+
+  var g = makeGraph(TEST_SERIES_NODUP, {
+    selectMode: 'euclidian',
+    stackedGraph: true,
+    highlightSeriesOpts: {strokeWidth: 2}
+  });
+
+  // Lock the series
+  g.setSelection(0, 'Y1', true);
+
+  // Mouse along y=1
+  DygraphOps.dispatchMouseMove(g, 0, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 1);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 1);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse along y=5
+  DygraphOps.dispatchMouseMove(g, 0, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.2, 5);
+  assert.equal(0, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.4, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.6, 5);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.8, 5);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 1, 5);
+  assert.equal(3, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  // Mouse up x=0.7
+  DygraphOps.dispatchMouseMove(g, 0.7, 1);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 2);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 3);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 4);
+  assert.equal(1, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+  DygraphOps.dispatchMouseMove(g, 0.7, 5);
+  assert.equal(2, g.getSelection());
+  assert.equal('Y1', g.highlightSet_);
+
+});
+});

--- a/auto_tests/tests/select_mode.js
+++ b/auto_tests/tests/select_mode.js
@@ -229,13 +229,13 @@ it('euclidian/no highlight/not stacked/no series lock', () => {
   assert.equal(0, g.getSelection());
 
   DygraphOps.dispatchMouseMove(g, 0.4, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
 
   DygraphOps.dispatchMouseMove(g, 0.6, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
 
   DygraphOps.dispatchMouseMove(g, 0.8, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
 
   DygraphOps.dispatchMouseMove(g, 1, 5);
   assert.equal(4, g.getSelection());
@@ -248,13 +248,13 @@ it('euclidian/no highlight/not stacked/no series lock', () => {
   assert.equal(2, g.getSelection());
 
   DygraphOps.dispatchMouseMove(g, 0.7, 3);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
 
   DygraphOps.dispatchMouseMove(g, 0.7, 4);
   assert.equal(2, g.getSelection());
 
   DygraphOps.dispatchMouseMove(g, 0.7, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
 
 });
 
@@ -308,15 +308,15 @@ it('closest-x/with highlight/not stacked/no series lock', () => {
   assert.equal('Y2', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.4, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.6, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.8, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 1, 5);
@@ -333,7 +333,7 @@ it('closest-x/with highlight/not stacked/no series lock', () => {
   assert.equal('Y2', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.7, 3);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y2', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.7, 4);
@@ -341,7 +341,7 @@ it('closest-x/with highlight/not stacked/no series lock', () => {
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.7, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 });
 
@@ -394,15 +394,15 @@ it('euclidian/with highlight/not stacked/no series lock', () => {
   assert.equal('Y2', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.4, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.6, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.8, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 1, 5);
@@ -419,7 +419,7 @@ it('euclidian/with highlight/not stacked/no series lock', () => {
   assert.equal('Y2', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.7, 3);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y2', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.7, 4);
@@ -427,7 +427,7 @@ it('euclidian/with highlight/not stacked/no series lock', () => {
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.7, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 });
 
@@ -876,23 +876,23 @@ it('euclidian/no highlight/not stacked/with series lock', () => {
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.2, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.4, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.6, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.8, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 1, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   // Mouse up x=0.7
@@ -913,7 +913,7 @@ it('euclidian/no highlight/not stacked/with series lock', () => {
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.7, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
 });
@@ -1054,23 +1054,23 @@ it('euclidian/with highlight/not stacked/with series lock', () => {
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.2, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.4, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.6, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.8, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 1, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
   // Mouse up x=0.7
@@ -1091,7 +1091,7 @@ it('euclidian/with highlight/not stacked/with series lock', () => {
   assert.equal('Y1', g.highlightSet_);
 
   DygraphOps.dispatchMouseMove(g, 0.7, 5);
-  assert.equal(2, g.getSelection()); // SHOULD BE 3 - getSelection BUG
+  assert.equal(3, g.getSelection());
   assert.equal('Y1', g.highlightSet_);
 
 });

--- a/src/dygraph-default-attrs.js
+++ b/src/dygraph-default-attrs.js
@@ -82,6 +82,8 @@ var DEFAULT_ATTRS = {
   rangeSelectorAlpha: 0.6,
   showInRangeSelector: null,
 
+  selectMode: 'closest-x',
+  
   // The ordering here ensures that central lines always appear above any
   // fill bars/error bars.
   plotter: [

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -821,6 +821,12 @@ OPTIONS_REFERENCE =  // <JSON>
     "labels": ["Data"],
     "type": "Dygraph.DataHandler",
     "description": "Custom DataHandler. This is an advanced customization. See http://bit.ly/151E7Aq."
+  },
+  "selectMode": {
+    "default": "closest-x",
+    "labels": ["Interactive Elements"],
+    "type": "string",
+    "description": "Defines how points are selected. Valid values are 'closest-x' and 'euclidian'. 'closest-x' selects the nearest point along the X axis, while 'euclidian' selects the closest point in any direction. If highlightSeriesOpts is set, this has no effect."
   }
 }
 ;  // </JSON>

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1614,15 +1614,15 @@ Dygraph.prototype.mouseMove_ = function(event) {
   var searchMode = this.getOption("selectMode");
   var searchSeries = undefined;
   var highlightSeries = undefined;
-  var closestPoint = null;
-  var closestIdx = null;
 
   if (this.isSeriesLocked()) {
     searchSeries = this.highlightSet_;
     if (this.getOption("highlightSeriesOpts")) {
       highlightSeries = searchSeries;
     }
-  } else if (this.getBooleanOption("stackedGraph") && this.getOption("highlightSeriesOpts")) {
+  } else if (this.getBooleanOption("stackedGraph") &&
+             this.getOption("highlightSeriesOpts")) {
+    
     searchSeries = this.findStackedPoint(canvasx, canvasy).seriesName;
     highlightSeries = searchSeries;
   } else if (this.getOption("highlightSeriesOpts")) {
@@ -1630,15 +1630,17 @@ Dygraph.prototype.mouseMove_ = function(event) {
   }
 
   if (searchMode == 'euclidian') {
-    closestPoint = this.findClosestPoint(canvasx, canvasy, searchSeries);
+    var closestPoint = this.findClosestPoint(canvasx, canvasy, searchSeries);
     if (this.getOption("highlightSeriesOpts")) {
       highlightSeries = closestPoint.seriesName;
     }
 
     selectionChanged = this.setSelection(closestPoint.row, highlightSeries);
   } else {
-    closestIdx = this.findClosestRow(canvasx, searchSeries);
-    selectionChanged = this.setSelection(closestIdx, highlightSeries);
+    selectionChanged = this.setSelection(
+      this.findClosestRow(canvasx, searchSeries),
+      highlightSeries
+      );
   }
 
   var callback = this.getFunctionOption("highlightCallback");

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1615,16 +1615,27 @@ Dygraph.prototype.mouseMove_ = function(event) {
   var searchSeries = undefined;
   var highlightSeries = undefined;
 
+  // If the series is locked, we can only search and highlight
+  // that series
   if (this.isSeriesLocked()) {
     searchSeries = this.highlightSet_;
     if (this.getOption("highlightSeriesOpts")) {
       highlightSeries = searchSeries;
     }
+
+  // If the graph is stacked AND we want to highlight the
+  // series, the selection will be based on the area
+  // of the graph under each series. Otherwise
+  // stacked graphs behave the same as non-stacked
   } else if (this.getBooleanOption("stackedGraph") &&
              this.getOption("highlightSeriesOpts")) {
     
     searchSeries = this.findStackedPoint(canvasx, canvasy).seriesName;
     highlightSeries = searchSeries;
+  
+  // If series highlight is set on its own, we switch to
+  // euclidian mode since we want to highlight the closest
+  // series to the mouse
   } else if (this.getOption("highlightSeriesOpts")) {
     searchMode = 'euclidian';
   }

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1879,17 +1879,9 @@ Dygraph.prototype.clearSelection = function() {
 Dygraph.prototype.getSelection = function() {
   if (!this.selPoints_ || this.selPoints_.length < 1) {
     return -1;
+  } else {
+    return this.selPoints_[0].idx;
   }
-
-  for (var setIdx = 0; setIdx < this.layout_.points.length; setIdx++) {
-    var points = this.layout_.points[setIdx];
-    for (var row = 0; row < points.length; row++) {
-      if (points[row].x == this.selPoints_[0].x) {
-        return points[row].idx;
-      }
-    }
-  }
-  return -1;
 };
 
 /**


### PR DESCRIPTION
This pull request implements a new `selectMode` option that allows switching the point selection mode between the closest X axis value (current behaviour) and the closest point to the mouse.

The option is activated by setting `selectMode` to either `closest-x` (the default current behaviour) or `euclidian`.

The changes that locked series, highlighted series and stacked graphs make to the selection behaviour have been carried across to the new `euclidian` mode to mimic existing behaviour as closely as possible. Tests have been added for all combinations of these options.

This work is related to issue #371. An additional change to `getSelection()` is required to handle multiple points with the same X axis value (#914), which is also included here.

There are two open questions:

1. I have put the documentation for `selectMode` under Interactive Elements. If you want it in another section, let me know.
2. I'm using `findStackedPoint` as it is currently written. However we now only use the series name, and none of the other information it returns. Should I cut down the method to only return a series name (and rename it to `findStackedSeries`), or leave it as it is in case it's useful in the future?