### PR TITLE
Allow setSelection to trigger highlightCallback and do so in synchronizer

### DIFF
--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1779,8 +1779,10 @@ Dygraph.prototype.updateSelection_ = function(opt_animFraction) {
  * @param { locked } optional If true, keep seriesName selected when mousing
  * over the graph, disabling closest-series highlighting. Call clearSelection()
  * to unlock it.
+ * @param { trigger_highlight_callback } optional If true, trigger any
+ * user-defined highlightCallback if highlightCallback has been set.
  */
-Dygraph.prototype.setSelection = function(row, opt_seriesName, opt_locked) {
+Dygraph.prototype.setSelection = function(row, opt_seriesName, opt_locked, opt_trigger_highlight_callback) {
   // Extract the points we've selected
   this.selPoints_ = [];
 
@@ -1831,6 +1833,18 @@ Dygraph.prototype.setSelection = function(row, opt_seriesName, opt_locked) {
 
   if (changed) {
     this.updateSelection_(undefined);
+
+    if (opt_trigger_highlight_callback) {
+      var callback = this.getFunctionOption("highlightCallback");
+      if (callback) {
+        var event = null;
+        callback.call(this, event,
+          this.lastx_,
+          this.selPoints_,
+          this.lastRow_,
+          this.highlightSet_);
+      }
+    }
   }
   return changed;
 };

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -217,7 +217,7 @@ function attachSelectionHandlers(gs, prevCallbacks) {
           }
           var idx = gs[i].getRowForX(x);
           if (idx !== null) {
-            gs[i].setSelection(idx, seriesName);
+            gs[i].setSelection(idx, seriesName, undefined, true);
           }
         }
         block = false;


### PR DESCRIPTION
Currently, there appears to be either a bug or a surprising behavior with extras/synchronizer.js where the synchronizer's selection of a data series in the synchronized graph fails to trigger the user's highlightCallback function.

This pull request adds a parameter to setSelection that allows specifying triggering of highlightCallback, which is then used by synchronizer.js to trigger the callback.

All existing tests from "npm run test" appear to still pass.
