### PR TITLE
Fix drawAxes to allow one of two Y axes to be drawn

### DIFF
--- a/auto_tests/tests/css.js
+++ b/auto_tests/tests/css.js
@@ -53,6 +53,7 @@ it('testExplicitParamSize', function() {
 
 // Verifies that setting a style on the div works.
 it('testExplicitStyleSize', function() {
+  this.timeout(5000);
   var opts = {
   };
   var graph = document.getElementById("graph");
@@ -67,6 +68,7 @@ it('testExplicitStyleSize', function() {
 
 // Verifies that CSS pixel styles on the div trump explicit parameters.
 it('testPixelStyleWins', function() {
+  this.timeout(5000);
   var opts = {
     width: 987,
     height: 654

--- a/auto_tests/tests/multiple_axes.js
+++ b/auto_tests/tests/multiple_axes.js
@@ -142,6 +142,69 @@ it('testMultiChartLabels', function() {
   // TODO(danvk): check relative positioning here: title on top, y left of y2.
 });
 
+// Test option to draw Y2 axis, but not Y1
+it('testOnlyDrawingSecondAxis', function() {
+  var data = getData();
+
+  var g = new Dygraph(
+    document.getElementById("graph"),
+    data,
+    {
+      labels: [ 'Date', 'Y1', 'Y2', 'Y3', 'Y4' ],
+      drawPoints : true,
+      pointSize : 3,
+      series : {
+        'Y4': {
+          axis: 'y2'
+        }
+      },
+      axes: {
+        y: {
+          drawAxis: false
+        },
+        y2: {
+          drawAxis: true
+        }
+      },
+    }
+  );
+
+  assert.isTrue(document.getElementsByClassName("dygraph-axis-label-y1").length == 0);
+  assert.isTrue(document.getElementsByClassName("dygraph-axis-label-y2").length > 0);
+});
+
+// Test default(?) Y-axis drawing: Y1 drawn, Y2 not drawn
+it('testNotDrawingSecondAxis', function() {
+  var data = getData();
+
+  var g = new Dygraph(
+    document.getElementById("graph"),
+    data,
+    {
+      labels: [ 'Date', 'Y1', 'Y2', 'Y3', 'Y4' ],
+      drawPoints : true,
+      pointSize : 3,
+      series : {
+        'Y4': {
+          axis: 'y2'
+        }
+      },
+      axes: {
+        y: {
+          drawAxis: true
+        },
+        y2: {
+          drawAxis: false
+        }
+      },
+    }
+  );
+
+  assert.isTrue(document.getElementsByClassName("dygraph-axis-label-y1").length > 0);
+  assert.isTrue(document.getElementsByClassName("dygraph-axis-label-y2").length == 0);
+
+});
+
 // Check that a chart w/o a secondary y-axis will not get a y2label, even if one
 // is specified.
 it('testNoY2LabelWithoutSecondaryAxis', function() {

--- a/src/plugins/axes.js
+++ b/src/plugins/axes.js
@@ -195,7 +195,10 @@ axes.prototype.willDrawChart = function(e) {
         if (top + fontSize + 3 > canvasHeight) {
           label.style.bottom = '0';
         } else {
-          label.style.top = top + 'px';
+          // The lowest tick on the y-axis often overlaps with the leftmost
+          // tick on the x-axis. Shift the bottom tick up a little bit to
+          // compensate if necessary.
+          label.style.top = Math.min(top, canvasHeight - (2 * fontSize)) + 'px';
         }
         // TODO: replace these with css classes?
         if (tick.axis === 0) {
@@ -210,18 +213,6 @@ axes.prototype.willDrawChart = function(e) {
         containerDiv.appendChild(label);
         this.ylabels_.push(label);
       });
-
-      // The lowest tick on the y-axis often overlaps with the leftmost
-      // tick on the x-axis. Shift the bottom tick up a little bit to
-      // compensate if necessary.
-      var bottomTick = this.ylabels_[0];
-      // Interested in the y2 axis also?
-      var fontSize = g.getOptionForAxis('axisLabelFontSize', 'y');
-      var bottom = parseInt(bottomTick.style.top, 10) + fontSize;
-      if (bottom > canvasHeight - fontSize) {
-        bottomTick.style.top = (parseInt(bottomTick.style.top, 10) -
-            fontSize / 2) + 'px';
-      }
     }
 
     // draw a vertical line on the left to separate the chart from the labels.

--- a/src/plugins/axes.js
+++ b/src/plugins/axes.js
@@ -160,7 +160,7 @@ axes.prototype.willDrawChart = function(e) {
     };
   };
 
-  if (g.getOptionForAxis('drawAxis', 'y')) {
+  if (g.getOptionForAxis('drawAxis', 'y') || g.getOptionForAxis('drawAxis', 'y2')) {
     if (layout.yticks && layout.yticks.length > 0) {
       var num_axes = g.numAxes();
       var getOptions = [makeOptionGetter('y'), makeOptionGetter('y2')];
@@ -176,6 +176,7 @@ axes.prototype.willDrawChart = function(e) {
           prec_axis = 'y2';
           getAxisOption = getOptions[1];
         }
+        if (!getAxisOption('drawAxis')) return;
         var fontSize = getAxisOption('axisLabelFontSize');
         y = area.y + tick.pos * area.h;
 
@@ -243,7 +244,7 @@ axes.prototype.willDrawChart = function(e) {
     context.stroke();
 
     // if there's a secondary y-axis, draw a vertical line for that, too.
-    if (g.numAxes() == 2) {
+    if (g.numAxes() == 2 && g.getOptionForAxis('drawAxis', 'y2')) {
       context.strokeStyle = g.getOptionForAxis('axisLineColor', 'y2');
       context.lineWidth = g.getOptionForAxis('axisLineWidth', 'y2');
       context.beginPath();


### PR DESCRIPTION
Hello. This fix is for a bug I noticed that prevented the drawAxes function to properly show only one Y axis when there is data for both. I added a test to cover Y1 drawn, but not Y2 and one for Y2 drawn, but not Y1. 

Separately, the docs state the default is that Y2 is not drawn, but the code has all axes drawn by default. I am not sure which is correct so I did not change either.

Thanks for the great work!
