### PR TITLE
Adds offset config for Legend div in 'follow' mode

### DIFF
--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -821,7 +821,20 @@ OPTIONS_REFERENCE =  // <JSON>
     "labels": ["Data"],
     "type": "Dygraph.DataHandler",
     "description": "Custom DataHandler. This is an advanced customization. See http://bit.ly/151E7Aq."
+  },
+  "topLegendOffset": {
+	"default": "-40",
+	"labels": ["Legend Top Offset"],
+	"type": "integer",
+	"description": "Top offset, in pixels, of the legend from current point."
+  },
+  "leftLegendOffset": {
+	"default": "5",
+	"labels": ["Legend Left Offset"],
+	"type": "integer",
+	"description": "Left offset, in pixels, of the legend from current point."
   }
+
 }
 ;  // </JSON>
 // NOTE: in addition to parsing as JS, this snippet is expected to be valid

--- a/src/plugins/legend.js
+++ b/src/plugins/legend.js
@@ -107,17 +107,18 @@ Legend.prototype.select = function(e) {
     var area = e.dygraph.plotter_.area;
     var labelsDivWidth = this.legend_div_.offsetWidth;
     var yAxisLabelWidth = e.dygraph.getOptionForAxis('axisLabelWidth', 'y');
+
     // determine floating [left, top] coordinates of the legend div
     // within the plotter_ area
-    // offset 50 px to the right and down from the first selection point
-    // 50 px is guess based on mouse cursor size
-    var leftLegend = points[0].x * area.w + 50;
-    var topLegend  = points[0].y * area.h - 50;
+    var leftLegendOffset = e.dygraph.getOption('leftLegendOffset');
+    var topLegendOffset = e.dygraph.getOption('topLegendOffset');
+    var leftLegend = points[0].x * area.w + leftLegendOffset;
+    var topLegend = points[0].y * area.h + topLegendOffset;
 
     // if legend floats to end of the chart area, it flips to the other
     // side of the selection point
     if ((leftLegend + labelsDivWidth + 1) > area.w) {
-      leftLegend = leftLegend - 2 * 50 - labelsDivWidth - (yAxisLabelWidth - area.x);
+      leftLegend = leftLegend - 2 * leftLegendOffset - labelsDivWidth - (yAxisLabelWidth - area.x);
     }
 
     e.dygraph.graphDiv.appendChild(this.legend_div_);


### PR DESCRIPTION
. At the moment, legend offset in **follow** mode is hard-coded at 50px
. Adds new config options **topLegendOffset** and **leftLegendOffset** in src/dygraph-options-reference.js
. Implements legend offsets only when (legendMode === 'follow') in src/plugins/legend.js

Please read the guide to making dygraphs changes:
http://dygraphs.com/changes.html

Pull Requests will only be accepted if:

- You clearly explain what you're adding and why you believe it's an
  improvement. For example: "Fixes issue #123".
- You adhere to the style of the rest of the dygraphs code base.
- You write an `auto_test` for the code that you're adding.

Be sure to document any new options you add. Also be aware that PRs which add
options are likely to be rejected. dygraphs already has many options. If you
can fit your feature into one of those or implement it as a plugin, it will be
more likely to get merged.
