### PR TITLE
Fix issue #611 in the drawing demo gallery

### DIFF
--- a/gallery/drawing.js
+++ b/gallery/drawing.js
@@ -119,6 +119,9 @@ Gallery.register(
             valueRange: valueRange,
             labels: [ 'Date', 'Value' ],
             interactionModel: {
+              // the next line is required when using the 
+              // defaultInteractionModel mousedown function.
+              willDestroyContextMyself: true, 
               mousedown: function (event, g, context) {
                 if (tool == 'zoom') {
                   Dygraph.defaultInteractionModel.mousedown(event, g, context);
@@ -135,24 +138,23 @@ Gallery.register(
                 }
               },
               mousemove: function (event, g, context) {
-                if (tool == 'zoom') {
-                  Dygraph.defaultInteractionModel.mousemove(event, g, context);
-                } else {
+                // note that the defaultInteractionModel dynamically binds
+                // it's own mousemove event inside the mousedown handler
+                if (tool != 'zoom') {
                   if (!isDrawing) return;
                   setPoint(event, g, context);
                 }
               },
               mouseup: function(event, g, context) {
-                if (tool == 'zoom') {
-                  Dygraph.defaultInteractionModel.mouseup(event, g, context);
-                } else {
+                // note that the defaultInteractionModel dynamically binds 
+                // it's own mouseup event inside the mousedown handler
+                if (tool != 'zoom') {
                   finishDraw();
                 }
               },
               mouseout: function(event, g, context) {
-                if (tool == 'zoom') {
-                  Dygraph.defaultInteractionModel.mouseout(event, g, context);
-                }
+                // note that the defaultInteractionModel does not use mouseout event, instead it
+                // detects when the mouse is outside the chart using a dynamically bound mousemove event 
               },
               dblclick: function(event, g, context) {
                 Dygraph.defaultInteractionModel.dblclick(event, g, context);

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -169,7 +169,16 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
     var g = gs[i];
     g.updateOptions({
       drawCallback: function(me, initial) {
-        if (block || initial) return;
+        if (block || initial) {
+          // call the users drawCallback even if we are blocked
+          for (var j = 0; j < gs.length; j++) {
+            if (gs[j] == me && prevCallbacks[j] && prevCallbacks[j].drawCallback) {
+              prevCallbacks[j].drawCallback.apply(gs[j], [gs[j]]);
+            }
+          }
+          return;
+        }
+        
         block = true;
         var opts = {
           dateWindow: me.xAxisRange()


### PR DESCRIPTION
This pull request fixes the broken zoom functionality  and console errors in the drawing demo.  It simply adds the willDestroyContextMyself attribute, and removes the now unimplemented functions in the defaultInteractionModel.  Comments have also been added to explain to users why calls are missing.

Sorry about the double commit, still getting a handle on pull request functionality.  13887ef corrects a problem where synchronizer.js would block the users drawCallback when updating the zoom of connected charts.