### PR TITLE
Feature/legend formatter dom elements

### DIFF
--- a/auto_tests/tests/plugins_legend.js
+++ b/auto_tests/tests/plugins_legend.js
@@ -113,6 +113,32 @@ it('should use a legendFormatter', function() {
   assert.equal(calls[2].series[0].y, undefined);
 });
 
+it('should use a legendFormatter which returns a DocumentFragment', function() {
+  var calls = [];
+  var labelsDiv = document.getElementById('label');
+  var g = new Dygraph(graph, 'X,Y\n1,2\n', {
+    color: 'red',
+    legend: 'always',
+    labelsDiv: labelsDiv,
+    legendFormatter: function(data) {
+      var fragment = document.createDocumentFragment();
+      var e = document.createElement('div');
+      e.innerText='Text Label';
+      fragment.appendChild(e);
+      calls.push(data);
+      return fragment;
+    }
+  });
+
+  assert(calls.length == 1);  // legend for no selected points
+
+  //check that labelsDiv has fragment children attached
+  assert.equal(labelsDiv.children.length, 1);
+  assert.equal(labelsDiv.children[0].nodeName, 'DIV');
+  assert.equal(labelsDiv.children[0].innerText, 'Text Label');
+
+});
+
 it('should work with highlight series', () => {
   var calls = [];
   var g = new Dygraph(graph, 'X,y1,y2\n1,2,3\n', {

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -461,7 +461,7 @@ OPTIONS_REFERENCE =  // <JSON>
   "legendFormatter": {
     "default": "null",
     "labels": ["Legend"],
-    "type": "function(data): string",
+    "type": "function(data): string or DocumentFragment node",
     "params": [
       [ "data", "An object containing information about the selection (or lack of a selection). This includes formatted values and series information. See <a href=\"https://github.com/danvk/dygraphs/pull/683\">here</a> for sample values." ]
     ],

--- a/src/plugins/legend.js
+++ b/src/plugins/legend.js
@@ -91,15 +91,19 @@ var escapeHTML = function(str) {
   return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 };
 
+var isString = function(s) {
+    return typeof(s) === 'string' || s instanceof String;
+};
+
 var replaceHTML = function(e, html) {
-  if (html instanceof Node &&
+  if (isString(html)) {
+    e.innerHTML = html;
+  } else if (html instanceof Node &&
       html.nodeType == Node.DOCUMENT_FRAGMENT_NODE) {
     e.innerHTML = '';
     e.appendChild(html);
-  } else if (html instanceof string) {
-    e.innerHTML = html;
   }
-}
+};
 
 Legend.prototype.select = function(e) {
   var xValue = e.selectedX;

--- a/src/plugins/legend.js
+++ b/src/plugins/legend.js
@@ -91,6 +91,16 @@ var escapeHTML = function(str) {
   return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 };
 
+var replaceHTML = function(e, html) {
+  if (html instanceof Node &&
+      html.nodeType == Node.DOCUMENT_FRAGMENT_NODE) {
+    e.innerHTML = '';
+    e.appendChild(html);
+  } else if (html instanceof string) {
+    e.innerHTML = html;
+  }
+}
+
 Legend.prototype.select = function(e) {
   var xValue = e.selectedX;
   var points = e.selectedPoints;
@@ -126,7 +136,7 @@ Legend.prototype.select = function(e) {
   }
 
   var html = Legend.generateLegendHTML(e.dygraph, xValue, points, this.one_em_width_, row);
-  this.legend_div_.innerHTML = html;
+  replaceHTML(this.legend_div_, html)
   this.legend_div_.style.display = '';
 };
 
@@ -141,7 +151,7 @@ Legend.prototype.deselect = function(e) {
   this.one_em_width_ = oneEmWidth;
 
   var html = Legend.generateLegendHTML(e.dygraph, undefined, undefined, oneEmWidth, null);
-  this.legend_div_.innerHTML = html;
+  replaceHTML(this.legend_div_, html)
 };
 
 Legend.prototype.didDrawChart = function(e) {
@@ -320,7 +330,7 @@ function generateLegendDashHTML(strokePattern, color, oneEmWidth) {
   var normalizedPattern = [];
   var loop;
 
-  // Compute the length of the pixels including the first segment twice, 
+  // Compute the length of the pixels including the first segment twice,
   // since we repeat it.
   for (i = 0; i <= strokePattern.length; i++) {
     strokePixelLength += strokePattern[i%strokePattern.length];


### PR DESCRIPTION
Fixes issue #958 

legendFormatter option now allows a string or a DocumentFragment to be returned. A test for the DocumentFragment case has been added.