### PR TITLE
add data index to legendFormatter data

### DIFF
--- a/src/plugins/legend.js
+++ b/src/plugins/legend.js
@@ -195,6 +195,7 @@ Legend.generateLegendHTML = function(g, x, sel_points, oneEmWidth, row) {
   var data = {
     dygraph: g,
     x: x,
+    i: row,
     series: []
   };
 


### PR DESCRIPTION
This adds the `row` index to the structure passed to the `legendFormatter`. Having the index enables quick indexing of external, unplotted auxiliary data for a point.
