### PR TITLE
Fixes issue #984 (Couldn't parse 20035000 as a date)

### DIFF
--- a/auto_tests/tests/data_types.js
+++ b/auto_tests/tests/data_types.js
@@ -1,0 +1,34 @@
+/** 
+ * @fileoverview Test cases for DygraphOptions.
+ */
+
+import Dygraph from '../../src/dygraph';
+
+describe("dygraph-data-types", function() {
+
+  cleanupAfterEach();
+
+  var graph;
+
+  beforeEach(function() {
+    graph = document.getElementById("graph");
+  });
+
+  /*
+   * Test to ensure ints are correctly interpreted as ints and not as dates
+   */
+  it('testNumberOfData', function() {
+    var opts = {
+      width: 480,
+      height: 320
+    };
+    var data = "x	y\n" +
+      "20033000	1\n" +
+      "20034000	2\n" +
+      "20035000	3\n" +
+      "20036000	4";
+
+    var g = new Dygraph(graph, data, opts);
+    assert.deepEqual(4, g.rawData_.length); 
+  });
+});

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -2608,10 +2608,7 @@ Dygraph.prototype.detectTypeFromString_ = function(str) {
       str.indexOf('/') >= 0 ||
       isNaN(parseFloat(str))) {
     isDate = true;
-  } else if (str.length == 8 && str > '19700101' && str < '20371231') {
-    // TODO(danvk): remove support for this format.
-    isDate = true;
-  }
+  } 
 
   this.setXAxisOptions_(isDate);
 };


### PR DESCRIPTION
Fixes problem described in https://github.com/danvk/dygraphs/issues/984

Date format 20035000 is problematic, because it causes error:

Couldn't parse 20035000 as a date
...
Couldn't parse 20251000 as a date
