### PR TITLE
two bugs fixed in the calculations of pinch-zoom

### DIFF
--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -418,12 +418,13 @@ DygraphInteraction.startTouch = function(event, g, context) {
   var touches = [];
   for (var i = 0; i < event.touches.length; i++) {
     var t = event.touches[i];
+    var rect = t.target.getBoundingClientRect()
     // we dispense with 'dragGetX_' because all touchBrowsers support pageX
     touches.push({
       pageX: t.pageX,
       pageY: t.pageY,
-      dataX: g.toDataXCoord(t.pageX),
-      dataY: g.toDataYCoord(t.pageY)
+      dataX: g.toDataXCoord(t.clientX-rect.left),
+      dataY: g.toDataYCoord(t.clientY-rect.top)
       // identifier: t.identifier
     });
   }

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -531,9 +531,10 @@ DygraphInteraction.moveTouch = function(event, g, context) {
   var didZoom = false;
   if (context.touchDirections.x) {
     g.dateWindow_ = [
-      c_init.dataX - swipe.dataX + (context.initialRange.x[0] - c_init.dataX) / xScale,
-      c_init.dataX - swipe.dataX + (context.initialRange.x[1] - c_init.dataX) / xScale
+      c_init.dataX - swipe.dataX / xScale + (context.initialRange.x[0] - c_init.dataX) / xScale,
+      c_init.dataX - swipe.dataX / xScale + (context.initialRange.x[1] - c_init.dataX) / xScale
     ];
+
     didZoom = true;
   }
 
@@ -545,8 +546,8 @@ DygraphInteraction.moveTouch = function(event, g, context) {
         // TODO(danvk): implement
       } else {
         axis.valueRange = [
-          c_init.dataY - swipe.dataY + (context.initialRange.y[0] - c_init.dataY) / yScale,
-          c_init.dataY - swipe.dataY + (context.initialRange.y[1] - c_init.dataY) / yScale
+          c_init.dataY - swipe.dataY / yScale + (context.initialRange.y[0] - c_init.dataY) / yScale,
+          c_init.dataY - swipe.dataY / yScale + (context.initialRange.y[1] - c_init.dataY) / yScale
         ];
         didZoom = true;
       }


### PR DESCRIPTION
In dygraph-interaction-model.js, DygraphInteraction.moveTouch, the following is done:

```
 g.dateWindow_ = [
      c_init.dataX - swipe.dataX + (context.initialRange.x[0] - c_init.dataX) / xScale,
      c_init.dataX - swipe.dataX + (context.initialRange.x[1] - c_init.dataX) / xScale
    ];
```
However, it seems that swipe.dataX is not properly scaled. It should be:       
`c_init.dataX - swipe.dataX / xScale + (context.initialRange.x[0] - c_init.dataX) / xScale`

In startTouch(), pageX, pageY is not appropriate for the calculation of dataX, dataY. This causes serious problems in the calculation of context.initialPinchCenter. The wrong calculations affect pinch-zoom when the x or y range is small and the graph div is farther to the bottom or right of the page.
For example, see http://jsfiddle.net/j63zvups/1/ and try to pinch-zoom in vertical, for scaling the y axis. You will get an ungovernable behaviour.
    
The solution is to use t.clientX and t.target.getBoundingClientRect().
    
To see that the old calculations were incorrect, consider this:
    
`toDataYCoord(y) = yRange[0] + (area.y + area.h - y) / area.h * (yRange[1] - yRange[0]);`
   
Now, if you pass y = pageY, you can see that (area.y + area.h - pageY) / area.h is wrong when pageY > area.y + area.h, which is the case when you scroll far enough.

With this two changes, dygraph behaves normally in my graphs and is usable.