### PR TITLE
Pinch zoom ux

### DIFF
--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -548,7 +548,7 @@ DygraphInteraction.moveTouch = function(event, g, context) {
     var initHalfWidth = (initialTouches[1].pageX - c_init.pageX);
     var initHalfHeight = (initialTouches[1].pageY - c_init.pageY);
     if (touches.length >= 2) {
-        const minAllowed = 50
+        const minAllowed = 5
         if (Math.abs(initHalfWidth) > minAllowed) {
           // sensitiveness dampening: smaller pinches count much less
           const damp = 1 / (Math.abs(initHalfWidth) - minAllowed)

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -599,16 +599,27 @@ DygraphInteraction.moveTouch = function(event, g, context) {
       if (logscale) {
         // TODO(danvk): implement
       } else {
+        var oldValueRange = axis.valueRange
         axis.valueRange = [
           c_init.dataY - swipe.dataY / yScale + (context.initialRange.y[0] - c_init.dataY) / yScale,
           c_init.dataY - swipe.dataY / yScale + (context.initialRange.y[1] - c_init.dataY) / yScale
         ];
-        if (yExtremes[i][0] <  yExtremes[i][1]) {
-            if (axis.valueRange[0] < yExtremes[i][0])
-                axis.valueRange[0] = yExtremes[i][0]
-            if (axis.valueRange[1] > yExtremes[i][1])
-                axis.valueRange[1] = yExtremes[i][1]
+        if (yExtremes[i][0] < yExtremes[i][1]) {
+            var pef = g.getNumericOption("panEdgeFraction") || 1/10
+            var a = yExtremes[i][0] - (yExtremes[i][1] - yExtremes[i][0]) * pef
+            var b = yExtremes[i][1] + (yExtremes[i][1] - yExtremes[i][0]) * pef
+            if (axis.valueRange[0] < a) {
+                axis.valueRange[0] = a
+                if (xScale == 1) // if it is a pan, do not scale
+                    axis.valueRange[1] = oldValueRange[1]
+            }
+            if (axis.valueRange[1] > b) {
+                axis.valueRange[1] = b
+                if (xScale == 1)
+                    axis.valueRange[0] = oldValueRange[0]
+            }
         }
+
         didZoom = true;
       }
     }

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -548,18 +548,22 @@ DygraphInteraction.moveTouch = function(event, g, context) {
     var initHalfWidth = (initialTouches[1].pageX - c_init.pageX);
     var initHalfHeight = (initialTouches[1].pageY - c_init.pageY);
     if (touches.length >= 2) {
-        // sensitiveness dampening: smaller pinches count much less
-        var nowHalfWidth = touches[1].pageX - c_now.pageX
-        var smallestHalfWidth = Math.min(Math.abs(nowHalfWidth), Math.abs(initHalfWidth))
-        var damp = 1 / smallestHalfWidth
-        xScale = (nowHalfWidth + damp) / (initHalfWidth + damp);
-  
-        var nowHalfHeight = touches[1].pageY - c_now.pageY
-        var smallestHalfHeight = Math.min(Math.abs(nowHalfHeight), Math.abs(initHalfHeight))
-        var damp = 1 / smallestHalfHeight
-        yScale = (nowHalfHeight + damp) / (initHalfHeight + damp);
+        var minAllowed = 5
 
-        console.log(xScale, yScale)
+        if (Math.abs(initHalfWidth) > minAllowed) {
+            // sensitiveness dampening: smaller pinches count much less
+            var damp = 1 / (Math.abs(initHalfWidth)-minAllowed)
+            
+            var nowHalfWidth = touches[1].pageX - c_now.pageX
+            xScale = (nowHalfWidth + damp) / (initHalfWidth + damp);
+        }
+
+        if (Math.abs(initHalfHeight) > minAllowed) {
+            var damp = 1 / (Math.abs(initHalfHeight) - minAllowed)
+
+            var nowHalfHeight = touches[1].pageY - c_now.pageY
+            yScale = (nowHalfHeight + damp) / (initHalfHeight + damp);
+        }
     }
   }
 

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -453,8 +453,8 @@ DygraphInteraction.startTouch = function(event, g, context) {
         dataY: 0.5 * (touches[0].dataY + touches[1].dataY)
     };
 
-    const xExtremes = g.xAxisExtremes()
-    const yExtremes = g.yAxisExtremes()
+    var xExtremes = g.xAxisExtremes()
+    var yExtremes = g.yAxisExtremes()
     if (xExtremes[0] >= xExtremes[1] || isOutOfExtremes(pinchCenter.dataX, xExtremes))
         context.pinchOutOfExtremes = true
     if (yExtremes.find(yEx => yEx[0] >= yEx[1] || isOutOfExtremes(pinchCenter.dataY, yEx)))
@@ -537,8 +537,8 @@ DygraphInteraction.moveTouch = function(event, g, context) {
   swipe.dataX = (swipe.pageX / g.plotter_.area.w) * dataWidth;
   swipe.dataY = (swipe.pageY / g.plotter_.area.h) * dataHeight;
 
-  const xExtremes = g.xAxisExtremes()
-  const yExtremes = g.yAxisExtremes()
+  var xExtremes = g.xAxisExtremes()
+  var yExtremes = g.yAxisExtremes()
 
   var xScale = 1.0, yScale = 1.0;
 
@@ -548,17 +548,18 @@ DygraphInteraction.moveTouch = function(event, g, context) {
     var initHalfWidth = (initialTouches[1].pageX - c_init.pageX);
     var initHalfHeight = (initialTouches[1].pageY - c_init.pageY);
     if (touches.length >= 2) {
-        const minAllowed = 5
-        if (Math.abs(initHalfWidth) > minAllowed) {
-          // sensitiveness dampening: smaller pinches count much less
-          const damp = 1 / (Math.abs(initHalfWidth) - minAllowed)
-          xScale = (touches[1].pageX - c_now.pageX + damp) / (initHalfWidth + damp);
-        }
+        // sensitiveness dampening: smaller pinches count much less
+        var nowHalfWidth = touches[1].pageX - c_now.pageX
+        var smallestHalfWidth = Math.min(Math.abs(nowHalfWidth), Math.abs(initHalfWidth))
+        var damp = 1 / smallestHalfWidth
+        xScale = (nowHalfWidth + damp) / (initHalfWidth + damp);
   
-        if (Math.abs(initHalfHeight) > minAllowed)  {
-          const damp = 1 / (Math.abs(initHalfHeight) - minAllowed)
-          yScale = (touches[1].pageY - c_now.pageY + damp) / (initHalfHeight + damp);
-        }
+        var nowHalfHeight = touches[1].pageY - c_now.pageY
+        var smallestHalfHeight = Math.min(Math.abs(nowHalfHeight), Math.abs(initHalfHeight))
+        var damp = 1 / smallestHalfHeight
+        yScale = (nowHalfHeight + damp) / (initHalfHeight + damp);
+
+        console.log(xScale, yScale)
     }
   }
 

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -515,16 +515,11 @@ DygraphInteraction.moveTouch = function(event, g, context) {
   const xExtremes = g.xAxisExtremes()
   const yExtremes = g.yAxisExtremes()
 
-  var xScale, yScale;
+  var xScale = 1.0, yScale = 1.0;
 
   // The residual bits are usually split into scale & rotate bits, but we split
   // them into x-scale and y-scale bits.
-  if (touches.length == 1) {
-    xScale = 1.0;
-    yScale = 1.0;
-  } else {
-    xScale = 1.0;
-    yScale = 1.0;
+  if (touches.length >= 2) {
     var initHalfWidth = (initialTouches[1].pageX - c_init.pageX);
     var initHalfHeight = (initialTouches[1].pageY - c_init.pageY);
     if (touches.length >= 2) {

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -572,7 +572,7 @@ DygraphInteraction.moveTouch = function(event, g, context) {
 
   var didZoom = false;
   if (context.touchDirections.x) {
-    var oldDateWindow = g.dateWindow_
+    var oldDateWindow = g.dateWindow_ || context.initialRange.x
     g.dateWindow_ = [
       c_init.dataX - swipe.dataX / xScale + (context.initialRange.x[0] - c_init.dataX) / xScale,
       c_init.dataX - swipe.dataX / xScale + (context.initialRange.x[1] - c_init.dataX) / xScale
@@ -602,7 +602,7 @@ DygraphInteraction.moveTouch = function(event, g, context) {
       if (logscale) {
         // TODO(danvk): implement
       } else {
-        var oldValueRange = axis.valueRange
+        var oldValueRange = axis.valueRange || context.initialRange.y
         axis.valueRange = [
           c_init.dataY - swipe.dataY / yScale + (context.initialRange.y[0] - c_init.dataY) / yScale,
           c_init.dataY - swipe.dataY / yScale + (context.initialRange.y[1] - c_init.dataY) / yScale

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -547,23 +547,21 @@ DygraphInteraction.moveTouch = function(event, g, context) {
   if (touches.length >= 2 && !context.pinchOutOfExtremes) {
     var initHalfWidth = (initialTouches[1].pageX - c_init.pageX);
     var initHalfHeight = (initialTouches[1].pageY - c_init.pageY);
-    if (touches.length >= 2) {
-        var minAllowed = 5
+    var minAllowed = 5
 
-        if (Math.abs(initHalfWidth) > minAllowed) {
-            // sensitiveness dampening: smaller pinches count much less
-            var damp = 1 / (Math.abs(initHalfWidth)-minAllowed)
-            
-            var nowHalfWidth = touches[1].pageX - c_now.pageX
-            xScale = (nowHalfWidth + damp) / (initHalfWidth + damp);
-        }
+    if (Math.abs(initHalfWidth) > minAllowed) {
+        // sensitiveness dampening: smaller pinches count much less
+        var damp = 1 / (Math.abs(initHalfWidth)-minAllowed)
+        
+        var nowHalfWidth = touches[1].pageX - c_now.pageX
+        xScale = (nowHalfWidth + damp) / (initHalfWidth + damp);
+    }
 
-        if (Math.abs(initHalfHeight) > minAllowed) {
-            var damp = 1 / (Math.abs(initHalfHeight) - minAllowed)
+    if (Math.abs(initHalfHeight) > minAllowed) {
+        var damp = 1 / (Math.abs(initHalfHeight) - minAllowed)
 
-            var nowHalfHeight = touches[1].pageY - c_now.pageY
-            yScale = (nowHalfHeight + damp) / (initHalfHeight + damp);
-        }
+        var nowHalfHeight = touches[1].pageY - c_now.pageY
+        yScale = (nowHalfHeight + damp) / (initHalfHeight + damp);
     }
   }
 

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -427,19 +427,23 @@ DygraphInteraction.startTouch = function(event, g, context) {
   var touches = [];
   for (var i = 0; i < event.touches.length; i++) {
     var t = event.touches[i];
+    var rect = t.target.getBoundingClientRect()
     // we dispense with 'dragGetX_' because all touchBrowsers support pageX
     touches.push({
       pageX: t.pageX,
       pageY: t.pageY,
-      dataX: g.toDataXCoord(t.pageX),
-      dataY: g.toDataYCoord(t.pageY)
+      dataX: g.toDataXCoord(t.clientX-rect.left),
+      dataY: g.toDataYCoord(t.clientY-rect.top)
       // identifier: t.identifier
     });
   }
   context.initialTouches = touches;
 
-  let pinchCenter
+  var pinchCenter
+  context.pinchOutOfExtremes = false
   if (touches.length >= 2) {
+
+    // only screen coordinates can be averaged (data coords could be log scale).
     pinchCenter = {
         pageX: 0.5 * (touches[0].pageX + touches[1].pageX),
         pageY: 0.5 * (touches[0].pageY + touches[1].pageY),
@@ -465,8 +469,8 @@ DygraphInteraction.startTouch = function(event, g, context) {
     // It's become a pinch!
     // In case there are 3+ touches, we ignore all but the "first" two.
 
-    // only screen coordinates can be averaged (data coords could be log scale).
     context.initialPinchCenter = pinchCenter
+
     // Make pinches in a 45-degree swath around either axis 1-dimensional zooms.
     var initialAngle = 180 / Math.PI * Math.atan2(
         context.initialPinchCenter.pageY - touches[0].pageY,
@@ -477,8 +481,9 @@ DygraphInteraction.startTouch = function(event, g, context) {
     if (initialAngle > 90) initialAngle = 90 - initialAngle;
 
     context.touchDirections = {
+      //TODO: it does not seem to work well
       //x: (initialAngle < (90 - 45/2)),
-     // y: (initialAngle > 45/2)
+      //y: (initialAngle > 45/2)
       x: true,
       y: true
     };

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -569,15 +569,25 @@ DygraphInteraction.moveTouch = function(event, g, context) {
 
   var didZoom = false;
   if (context.touchDirections.x) {
+    var oldDateWindow = g.dateWindow_
     g.dateWindow_ = [
       c_init.dataX - swipe.dataX / xScale + (context.initialRange.x[0] - c_init.dataX) / xScale,
       c_init.dataX - swipe.dataX / xScale + (context.initialRange.x[1] - c_init.dataX) / xScale
     ];
     if (xExtremes[0] < xExtremes[1]) {
-        if (g.dateWindow_[0] < xExtremes[0])
-            g.dateWindow_[0] = xExtremes[0]
-        if (g.dateWindow_[1] > xExtremes[1])
-            g.dateWindow_[1] = xExtremes[1]
+        var pef = g.getNumericOption("panEdgeFraction") || 1/10
+        var a = xExtremes[0] - (xExtremes[1] - xExtremes[0]) * pef
+        var b = xExtremes[1] + (xExtremes[1] - xExtremes[0]) * pef
+        if (g.dateWindow_[0] < a) {
+            g.dateWindow_[0] = a
+            if (xScale == 1) // if it is a pan, do not scale the window
+                g.dateWindow_[1] = oldDateWindow[1]
+        }
+        if (g.dateWindow_[1] > b) {
+            g.dateWindow_[1] = b
+            if (xScale == 1)
+                g.dateWindow_[0] = oldDateWindow[0]
+        }
     }
     didZoom = true;
   }

--- a/src/dygraph-interaction-model.js
+++ b/src/dygraph-interaction-model.js
@@ -457,8 +457,10 @@ DygraphInteraction.startTouch = function(event, g, context) {
     if (initialAngle > 90) initialAngle = 90 - initialAngle;
 
     context.touchDirections = {
-      x: (initialAngle < (90 - 45/2)),
-      y: (initialAngle > 45/2)
+      //x: (initialAngle < (90 - 45/2)),
+     // y: (initialAngle > 45/2)
+      x: true,
+      y: true
     };
   }
 
@@ -516,17 +518,24 @@ DygraphInteraction.moveTouch = function(event, g, context) {
   if (touches.length == 1) {
     xScale = 1.0;
     yScale = 1.0;
-  } else if (touches.length >= 2) {
+  } else {
+    xScale = 1.0;
+    yScale = 1.0;
     var initHalfWidth = (initialTouches[1].pageX - c_init.pageX);
-    xScale = (touches[1].pageX - c_now.pageX) / initHalfWidth;
-
     var initHalfHeight = (initialTouches[1].pageY - c_init.pageY);
-    yScale = (touches[1].pageY - c_now.pageY) / initHalfHeight;
+    if (touches.length >= 2) {
+        if (Math.abs(initHalfWidth) > 50)
+          xScale = (touches[1].pageX - c_now.pageX) / initHalfWidth;
+  
+        if (Math.abs(initHalfHeight) > 50) 
+          yScale = (touches[1].pageY - c_now.pageY) / initHalfHeight;
+    }
   }
 
   // Clip scaling to [1/8, 8] to prevent too much blowup.
   xScale = Math.min(8, Math.max(0.125, xScale));
   yScale = Math.min(8, Math.max(0.125, yScale));
+
 
   var didZoom = false;
   if (context.touchDirections.x) {


### PR DESCRIPTION
This pull request is an experimentation on improving the UX of pinch-zoom.
It starts from pull request [990](https://github.com/danvk/dygraphs/pull/990), which fixes two functional bugs, and it adds the following:

- do not go out of the graph extremes (g.xAxisExtremes()), both during pan and during zoom. Use  g.getNumericOption("panEdgeFraction") to have a tolerance about this. Perhaps, this fixes [713](https://github.com/danvk/dygraphs/issues/713).
- sensitiveness dampening: smaller pinches count much less for scaling
- context.pinchOutOfExtremes: do not pinch-zoom if the center of the pinch is out of the extremes of the axes
- There was this feature: "make pinches in a 45-degree swath around either axis 1-dimensional zooms". I found it needed improvement, so I disabled it. Without it, I find the graph to be very usable, perhaps thanks to the dampness of sensitiveness. But perhaps, you want to enable it. It is easy: just de-comment two lines.

