### PR TITLE
documentation about annotations xval option

### DIFF
--- a/docs/annotations.html
+++ b/docs/annotations.html
@@ -145,7 +145,7 @@ no-op: it simply causes the chart to refresh.</p>
 
 <p style="clear:both">Annotations are JavaScript dictionaries. The <code>series</code> and <code>x</code> fields are required: they indicate which point the annotation should be attached to. If specified, <code>shortText</code> will appear on the annotation "flag". If you don't specify <code>shortText</code>, you can specify <code>icon</code> instead to display a small picture. The <code>text</code> parameter specifies hovertext. If you highlight the annotation and leave the mouse still, it will appear.</p>
 
-<p>If you are using <a href="http://dygraphs.com/data.html#array">native format</a>, you need to pass in a numeric value for the <code>x</code> field. For a numeric x-axis, simply pass in the x-value of the data point on which you wish to attach the annotation. For a date axis, pass in <code>Date.parse('YYYY/MM/DD')</code>. This returns milliseconds since epoch for the date.</p>
+<p>If you are using <a href="http://dygraphs.com/data.html#array">native format</a>, you need to pass in a numeric value for the <code>xval</code> field. For a numeric x-axis, simply pass in the x-value of the data point on which you wish to attach the annotation. For a date axis, pass in <code>Date.parse('YYYY/MM/DD')</code>. This returns milliseconds since epoch for the date. As an alternative, use the <code>x</code> field, see table below.</p>
 
 <h3>Modifying Annotations</h3>
 <p>To remove or modify existing annotations, call the
@@ -186,7 +186,8 @@ g.ready(function() {
 <table class="thinborder">
 <tr> <td><b>Property</b></td><td><b>Description</b></td> </tr>
 <tr><td><code>series</code></td> <td><i>Required</i> The name of the series to which the annotated point belongs.</td></tr>
-<tr><td><code>x</code></td><td><i>Required</i> The x value of the point. This should be the same as the value you specified in your CSV file, e.g. "2010-09-13".</td></tr>
+<tr><td><code>x</code></td><td><i>Required</i> The x value of the point. This should be the same as the value you specified in your CSV file, e.g. "2010-09-13". As an alternative, use the <code>xval</code> field.</td></tr>
+<tr><td><code>xval</code></td><td><i>Required</i> The numeric x value of the point. E.g. if you specified in your CSV file "2010-09-13", set xval to Date.parse("2010-09-13"). As an alternative, use the <code>x</code> field.</td></td></tr>
 <tr><td><code>shortText</code></td><td>Text that will appear on the annotation's flag.</td></tr>
 <tr><td><code>text</code></td><td>A longer description of the annotation which will appear when the user hovers over it.</td></tr>
 <tr><td><code>icon</code></td><td>Specify in place of <code>shortText</code> to mark the annotation with an image rather than text. If you specify this, you must specify <code>width</code> and <code>height</code>.</td></tr>


### PR DESCRIPTION
Documentation about xval option for g.setAnnotations() was missing. Added in this commit.

I was in a situation where I had to use xval. X values were dates passed as Date objects in GViZ format. So, the only sensible thing I could pass to setAnnotations was the milliseconds (.getTime()). 
So I needed the xval option and I could not use the x option.

