### PR TITLE
The event `preventDefault` issue

### DIFF
--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -96,7 +96,7 @@ export var getContext = function(canvas) {
  * @private
  */
 export var addEvent = function addEvent(elem, type, fn) {
-  elem.addEventListener(type, fn, false);
+  elem.addEventListener(type, fn, { passive: true });
 };
 
 /**


### PR DESCRIPTION
Because of the error: `Consider marking event handler as 'passive' to make the page more responsive`
```
Passive event listeners are a new feature in the DOM spec that enable developers to opt-in to better scroll performance by eliminating the need for scrolling to block on touch and wheel event listeners. Developers can annotate touch and wheel listeners with {passive: true} to indicate that they will never invoke preventDefault.
```
https://stackoverflow.com/a/61248767/5113030

Actually, I don't know if this would be correct, though.
Please, consider looking.

Please read the guide to making dygraphs changes:
http://dygraphs.com/changes.html

Pull Requests will only be accepted if:

- You clearly explain what you're adding and why you believe it's an
  improvement. For example: "Fixes issue #123".
- You adhere to the style of the rest of the dygraphs code base.
- You write an `auto_test` for the code that you're adding.

Be sure to document any new options you add. Also be aware that PRs which add
options are likely to be rejected. dygraphs already has many options. If you
can fit your feature into one of those or implement it as a plugin, it will be
more likely to get merged.
