### PR TITLE
Fix for double paint of grid of x-axis

### DIFF
--- a/src/plugins/grid.js
+++ b/src/plugins/grid.js
@@ -103,7 +103,6 @@ grid.prototype.willDrawChart = function(e) {
       ctx.beginPath();
       ctx.moveTo(x, y);
       ctx.lineTo(x, area.y);
-      ctx.closePath();
       ctx.stroke();
     });
     if (stroking) {


### PR DESCRIPTION
```ctx.closePath();``` makes second draw of the line. With solid line there is no difference but performance, but when the line has any pattern, this second draw makes a mess.