### PR TITLE
fix label units

### DIFF
--- a/auto_tests/tests/axis_labels.js
+++ b/auto_tests/tests/axis_labels.js
@@ -646,11 +646,11 @@ it('testSmallLabelKMB', function() {
                    Util.getYLabels());
 });
 
-it('testSmallLabelKMG2', function() {
+it('testSmallLabelKMG2legacy', function() {
   var data = [];
   data.push([0, 0]);
-  data.push([1, 1e-6]);
-  data.push([2, 2e-6]);
+  data.push([1, 1 * (2**-20)]);
+  data.push([2, 2 * (2**-20)]);
 
   var g = new Dygraph(
     document.getElementById("graph"),
@@ -659,15 +659,14 @@ it('testSmallLabelKMG2', function() {
       labels: [ 'X', 'bar' ],
       axes : {
         y: {
+          labelsKMB: true,
           labelsKMG2: true
         }
       }
     }
   );
 
-  // TODO(danvk): this is strange--the values aren't on powers of two, and are
-  // these units really used for powers of two in <1? See issue #571.
-  assert.deepEqual(['0', '0.48u', '0.95u', '1.43u', '1.91u'],
+  assert.deepEqual(['0', '256n', '512n', '768n', '1µ', '1.25µ', '1.5µ', '1.75µ', '2µ'],
                    Util.getYLabels());
 });
 

--- a/auto_tests/tests/axis_labels.js
+++ b/auto_tests/tests/axis_labels.js
@@ -646,6 +646,29 @@ it('testSmallLabelKMB', function() {
                    Util.getYLabels());
 });
 
+it('testSmallLabelKMG2', function() {
+  var data = [];
+  data.push([0, 0]);
+  data.push([1, 1 * (2**-20)]);
+  data.push([2, 2 * (2**-20)]);
+
+  var g = new Dygraph(
+    document.getElementById("graph"),
+    data,
+    {
+      labels: [ 'X', 'bar' ],
+      axes : {
+        y: {
+          labelsKMG2: true
+        }
+      }
+    }
+  );
+
+  assert.deepEqual(['0', '256p-30', '512p-30', '768p-30', '1p-20', '1.25p-20', '1.5p-20', '1.75p-20', '2p-20'],
+                   Util.getYLabels());
+});
+
 it('testSmallLabelKMG2legacy', function() {
   var data = [];
   data.push([0, 0]);

--- a/auto_tests/tests/axis_labels.js
+++ b/auto_tests/tests/axis_labels.js
@@ -574,7 +574,7 @@ it('testLabelKMB', function() {
     }
   );
 
-  assert.deepEqual(["0", "500", "1K", "1.5K", "2K"], Util.getYLabels());
+  assert.deepEqual(["0", "500", "1k", "1.5k", "2k"], Util.getYLabels());
 });
 
 it('testLabelKMG2', function() {
@@ -596,7 +596,7 @@ it('testLabelKMG2', function() {
     }
   );
 
-  assert.deepEqual(["0","256","512","768","1k","1.25k","1.5k","1.75k","2k"],
+  assert.deepEqual(["0","256","512","768","1Ki","1.25Ki","1.5Ki","1.75Ki","2Ki"],
                    Util.getYLabels());
 });
 
@@ -618,7 +618,7 @@ it('testLabelKMG2_top', function() {
   );
 
   assert.deepEqual(
-      ["0","256","512","768","1k","1.25k","1.5k","1.75k","2k"],
+      ["0","256","512","768","1Ki","1.25Ki","1.5Ki","1.75Ki","2Ki"],
       Util.getYLabels());
 });
 
@@ -641,8 +641,7 @@ it('testSmallLabelKMB', function() {
     }
   );
 
-  // TODO(danvk): use prefixes here (e.g. m, µ, n)
-  assert.deepEqual(['0', '5.00e-7', '1.00e-6', '1.50e-6', '2.00e-6'],
+  assert.deepEqual(['0', '500n', '1µ', '1.5µ', '2µ'],
                    Util.getYLabels());
 });
 
@@ -865,13 +864,13 @@ it('testLabelsKMBPerAxis', function() {
   // BUG : https://code.google.com/p/dygraphs/issues/detail?id=488
   assert.deepEqual(["1000","2000","3000"], Util.getXLabels());
   assert.deepEqual(["0","500","1000","1500","2000"], Util.getYLabels(1));
-  assert.deepEqual(["0","500","1K","1.5K","2K"], Util.getYLabels(2));
+  assert.deepEqual(["0","500","1k","1.5k","2k"], Util.getYLabels(2));
 });
 
 /*
  * This test shows that you can override labelsKMG2 on the axis level.
  */
-it('testLabelsKMBG2IPerAxis', function() {
+it('testLabelsKMG2PerAxis', function() {
   var g = new Dygraph(
       document.getElementById("graph"),
       "x,a,b\n" +
@@ -895,7 +894,7 @@ it('testLabelsKMBG2IPerAxis', function() {
   // BUG : https://code.google.com/p/dygraphs/issues/detail?id=488
   assert.deepEqual(["1024","2048","3072"], Util.getXLabels());
   assert.deepEqual(["0","500","1000","1500","2000"], Util.getYLabels(1));
-  assert.deepEqual(["0","500","1000","1.46k","1.95k"], Util.getYLabels(2));
+  assert.deepEqual(["0","500","1000","1.46Ki","1.95Ki"], Util.getYLabels(2));
 });
 
 /**

--- a/auto_tests/tests/multiple_axes.js
+++ b/auto_tests/tests/multiple_axes.js
@@ -58,7 +58,7 @@ it('testBasicMultipleAxes', function() {
   );
 
   assert.deepEqual(["0","20","40","60","80","100"], Util.getYLabels("1"));
-  assert.deepEqual(["900K","1.12M","1.34M","1.55M","1.77M","1.99M"], Util.getYLabels("2"));
+  assert.deepEqual(["900k","1.12M","1.34M","1.55M","1.77M","1.99M"], Util.getYLabels("2"));
 });
 
 it('testTwoAxisVisibility', function() {
@@ -198,7 +198,7 @@ it('testValueRangePerAxisOptions', function() {
     }
   );
   assert.deepEqual(["40", "45", "50", "55", "60", "65"], Util.getYLabels("1"));
-  assert.deepEqual(["900K","1.1M","1.3M","1.5M","1.7M","1.9M"], Util.getYLabels("2"));
+  assert.deepEqual(["900k","1.1M","1.3M","1.5M","1.7M","1.9M"], Util.getYLabels("2"));
   
   g.updateOptions(
     {

--- a/auto_tests/tests/xhr.js
+++ b/auto_tests/tests/xhr.js
@@ -6,8 +6,8 @@
  * This can be done with
  *
  *     npm install http-server
- *     http-server
- *     open http://localhost:8080/auto_tests/runner.html
+ *     http-server -p 8081
+ *     open http://localhost:8081/auto_tests/runner.html
  *
  */
 

--- a/scripts/generate-coverage.sh
+++ b/scripts/generate-coverage.sh
@@ -20,7 +20,7 @@ cp -r dist/auto_tests coverage/
 browserify coverage/auto_tests/tests/*.js -o coverage/tests.js
 
 # Run http-server and save its PID for cleanup
-http-server > /dev/null &
+http-server -p 8082 > /dev/null &
 SERVER_PID=$!
 function finish() {
   kill -TERM $SERVER_PID
@@ -34,7 +34,7 @@ sleep 1
 # This produces coverage/coverage.json
 phantomjs \
   ./node_modules/mocha-phantomjs/lib/mocha-phantomjs.coffee \
-  http://localhost:8080/auto_tests/coverage.html \
+  http://localhost:8082/auto_tests/coverage.html \
   spec '{"hooks": "mocha-phantomjs-istanbul", "coverageFile": "coverage/coverage.json"}'
 
 if [ $CI ]; then

--- a/src/dygraph-options-reference.js
+++ b/src/dygraph-options-reference.js
@@ -268,7 +268,7 @@ OPTIONS_REFERENCE =  // <JSON>
     "default": "false",
     "labels": ["Value display/formatting"],
     "type": "boolean",
-    "description": "Show k/M/G for kilo/Mega/Giga on y-axis. This is different than <code>labelsKMB</code> in that it uses base 2, not 10."
+    "description": "Show Ki/Mi/Gi for powers of 1024 on y-axis. If used together with <code>labelsKMB</code> (deprecated), K/M/G are used instead."
   },
   "delimiter": {
     "default": ",",
@@ -489,7 +489,7 @@ OPTIONS_REFERENCE =  // <JSON>
     "default": "false",
     "labels": ["Value display/formatting"],
     "type": "boolean",
-    "description": "Show K/M/B for thousands/millions/billions on y-axis."
+    "description": "Show k/M/B for thousands/millions/billions on y-axis."
   },
   "rightGap": {
     "default": "5",

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -1092,7 +1092,7 @@ export function parseFloat_(x, opt_line_no, opt_line) {
 var KMB_LABELS_LARGE = [ 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y' ];
 var KMB_LABELS_SMALL = [ 'm', 'µ', 'n', 'p', 'f', 'a', 'z', 'y' ];
 var KMG2_LABELS_LARGE = [ 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi' ];
-var KMG2_LABELS_SMALL = [ /* not provided in IEC 60027-2 */ ];
+var KMG2_LABELS_SMALL = [ 'p-10', 'p-20', 'p-30', 'p-40', 'p-50', 'p-60', 'p-70', 'p-80' ];
 /* if both are given (legacy/deprecated use only) */
 var KMB2_LABELS_LARGE = [ 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y' ];
 var KMB2_LABELS_SMALL = KMB_LABELS_SMALL;

--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -1162,7 +1162,7 @@ export function numberValueFormatter(x, opts) {
         }
       }
       // not reached, fall through safely though should it ever be
-    } else if ((absx < 1) && (m_labels.length > 0)) {
+    } else if ((absx < 1) /* && (m_labels.length > 0) */) {
       j = 0;
       while (j < m_labels.length) {
         ++j;


### PR DESCRIPTION
This fixes #994 and #571 by:

- using the correct SI units for `labelsKMB`
- using the correct IEC 60027-2 units for `labelsKMG2`
  - unless `labelsKMB` is _also_ given, in which case the “legacy” units (basically the same as `labelsKMB` except with `K` instead of `k` for Kibi) are used instead
  - for the nōn-KMB KMG2 case, use binary float-style “`p-10`” notation for the “small” units; the way `numericTicks()` operates makes it basically necessary to have “small” units for all labelling styles
- fix the KMG2-related small label tests by picking values that make checking the labels properly possible