### PR TITLE
Crosshair plugin runtime error on moving cursor out fix

### DIFF
--- a/src/extras/crosshair.js
+++ b/src/extras/crosshair.js
@@ -66,12 +66,14 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
     ctx.clearRect(0, 0, width, height);
     ctx.strokeStyle = this.strokeStyle_;
     ctx.beginPath();
-
-    var canvasx = Math.floor(e.dygraph.selPoints_[0].canvasx) + 0.5; // crisper rendering
-
-    if (this.direction_ === "vertical" || this.direction_ === "both") {
-      ctx.moveTo(canvasx, 0);
-      ctx.lineTo(canvasx, height);
+    
+    if (e.dygraph.selPoints_.length !== 0) {
+      var canvasx = Math.floor(e.dygraph.selPoints_[0].canvasx) + 0.5; // crisper rendering
+  
+      if (this.direction_ === "vertical" || this.direction_ === "both") {
+        ctx.moveTo(canvasx, 0);
+        ctx.lineTo(canvasx, height);
+      }
     }
 
     if (this.direction_ === "horizontal" || this.direction_ === "both") {


### PR DESCRIPTION
It is difficult to provide an example to test as the problem was discovered when using electron + react desktop application, but here is description and a screenshot of the error.

Having several graphs synchronized using synchronize plugin and having crosshair plugin used on them, doing these steps causes the error:
1. Zooming in one of the synced graphs
2. Moving cursor in and out of application bounds right after that (without clicking anywhere after zooming in)

![crosshair-error](https://user-images.githubusercontent.com/58081918/230755051-bba1dc65-9a16-4b3d-9e41-83b49f64573e.png)

Checking of `selPoints_.length !== 0` fixed it