### PR TITLE
Synchronizer plugin - selectClosest option

### DIFF
--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -36,6 +36,11 @@
  *
  * You may also set `range: false` if you wish to only sync the x-axis.
  * The `range` option has no effect unless `zoom` is true (the default).
+ *
+ * Synchronizer selection option selects points by exact values on x-axes.
+ * If graphs have different x-axes values, you may use
+ * `selectionClosest: true` to select points closest to hovered ones,
+ * corresponding to their x values.
  */
 
 /* loader wrapper to allow browser use and ES6 imports */
@@ -176,25 +181,29 @@ function arraysAreEqual(a, b) {
 function closestIdx(gs, x) {
   var points = gs.layout_.points[0];
   
-  // if graph has no data or single entry
-  var highestI = points.length - 1;
-  if (highestI < 0) return null;
-  if (highestI === 0) return points[0].idx;
+  // If graph has no data or single entry
+  if (points.length === 0)
+    return null;
+  if (points.length === 1)
+    return points[0].idx;
   
   var lowestI = 0;
+  var highestI = points.length - 1;
   
-  // if values of x axis are in descending order, reverse searching borders
+  // If values of x axis are in descending order, reverse searching borders
   if (points[0].xval > points[highestI].xval) {
     lowestI = highestI;
     highestI = 0;
   }
   
   while (true) {
-    var middleI = Math.round( (lowestI + highestI) * 0.5 );
-    if (middleI === lowestI || middleI === highestI) break;
+    var middleI = Math.round((lowestI + highestI) * 0.5);
+    if (middleI === lowestI || middleI === highestI)
+        break;
     
     var middleX = points[middleI].xval;
-    if (middleX === x) return points[middleI].idx;
+    if (middleX === x)
+        return points[middleI].idx;
     
     if (x < middleX) {
       highestI = middleI;
@@ -205,24 +214,37 @@ function closestIdx(gs, x) {
   
   var closestI;
   
-  // if graph in stepPlot mode, check right point for match
-  // if right point matched, return it, otherwise return left point
-  // if graph is not in stepPlot mode, return closest by x value point
+  /* 
+   * If graph in stepPlot mode, check right point for match
+   * If right point matched, return it, otherwise return left point
+   * If graph is not in stepPlot mode, return closest by x value point
+   */
   if (gs.getOption('stepPlot') === true) {
     if (lowestI < highestI) {
-      closestI = points[highestI].xval === x ? highestI : lowestI;
+      if (points[highestI].xval === x)
+        closestI = highestI;
+      else
+        closestI = lowestI;
     } else {
-      closestI = points[lowestI].xval === x ? lowestI : highestI;
+      if (points[lowestI].xval === x)
+        closestI = lowestI;
+      else
+        closestI = highestI;
     }
   } else {
-    closestI = x - points[lowestI].xval < points[highestI].xval - x ? lowestI : highestI;
+    if (x - points[lowestI].xval <= points[highestI].xval - x)
+      closestI = lowestI;
+    else
+      closestI = highestI;
   }
   
   return points[closestI].idx;
 }
 
 function isInsideDateWindow(gs, idx) {
-  if (idx === null) return false;
+  if (idx === null)
+    return false;
+  
   var xAxisRange = gs.xAxisRange();
   var min, max;
   if (xAxisRange[0] <= xAxisRange[1]) {
@@ -309,14 +331,15 @@ function attachSelectionHandlers(gs, syncOpts, prevCallbacks) {
             idx = gs[i].getRowForX(x);
           } else {
             idx = null;
-            if (gs[i].numRows() === me.numRows()) idx = gs[i].getRowForX(x);
-            if (idx === null) idx = closestIdx(gs[i], x);
+            if (gs[i].numRows() === me.numRows())
+              idx = gs[i].getRowForX(x);
+            if (idx === null)
+              idx = closestIdx(gs[i], x);
           }
-          if (isInsideDateWindow(gs[i], idx)) {
+          if (isInsideDateWindow(gs[i], idx))
             gs[i].setSelection(idx, seriesName, undefined, true);
-          } else {
+          else
             gs[i].clearSelection();
-          }
         }
         block = false;
       },

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -203,7 +203,11 @@ function closestIdx(gs, x) {
     }
   }
   
-  var closestI = x - points[lowestI].xval < points[highestI].xval - x ? lowestI : highestI;
+  var closestI;
+  
+  // if graph in stepPlot mode, return left point, otherwise closest x value point
+  if (gs.getOption('stepPlot') === true) closestI = lowestI < highestI ? lowestI : highestI;
+  else closestI = x - points[lowestI].xval < points[highestI].xval - x ? lowestI : highestI;
   
   return points[closestI].idx;
 }

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -175,37 +175,37 @@ function arraysAreEqual(a, b) {
 
 function closestIdx(gs, x) {
   // if graph has no data or single entry
-  var highestI = gs.numRows() - 1
-  if (highestI < 0) return null
-  if (highestI === 0) return 0
+  var highestI = gs.numRows() - 1;
+  if (highestI < 0) return null;
+  if (highestI === 0) return 0;
   
-  var lowestI = 0
+  var lowestI = 0;
   
   // if values of x axis are in descending order, reverse searching borders
   if (gs.getValue(0, 0) > gs.getValue(highestI, 0)) {
-    lowestI = highestI
-    highestI = 0
+    lowestI = highestI;
+    highestI = 0;
   }
   
   while (true) {
-    var middleI = Math.round( (lowestI + highestI) * 0.5 )
-    if (middleI === lowestI || middleI === highestI) break
+    var middleI = Math.round( (lowestI + highestI) * 0.5 );
+    if (middleI === lowestI || middleI === highestI) break;
     
-    var middleX = gs.getValue(middleI, 0)
-    if (middleX === x) return middleI
+    var middleX = gs.getValue(middleI, 0);
+    if (middleX === x) return middleI;
     
     if (x < middleX) {
-      highestI = middleI
+      highestI = middleI;
     } else {
-      lowestI = middleI
+      lowestI = middleI;
     }
   }
   
-  var lowestValue = gs.getValue(lowestI, 0)
-  var highestValue = gs.getValue(highestI, 0)
-  var closestI = x - lowestValue < highestValue - x ? lowestI : highestI
+  var lowestValue = gs.getValue(lowestI, 0);
+  var highestValue = gs.getValue(highestI, 0);
+  var closestI = x - lowestValue < highestValue - x ? lowestI : highestI;
   
-  return closestI
+  return closestI;
 }
 
 function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
@@ -276,13 +276,13 @@ function attachSelectionHandlers(gs, syncOpts, prevCallbacks) {
             }
             continue;
           }
-          var idx
+          var idx;
           if (!syncOpts.selectionClosest) {
             idx = gs[i].getRowForX(x);
           } else {
-            idx = null
+            idx = null;
             if (gs[i].numRows() === me.numRows()) idx = gs[i].getRowForX(x);
-            if (idx === null) idx = closestIdx(gs[i], x)
+            if (idx === null) idx = closestIdx(gs[i], x);
           }
           if (idx !== null) {
             gs[i].setSelection(idx, seriesName, undefined, true);

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -174,15 +174,17 @@ function arraysAreEqual(a, b) {
 }
 
 function closestIdx(gs, x) {
+  var points = gs.layout_.points[0];
+  
   // if graph has no data or single entry
-  var highestI = gs.numRows() - 1;
+  var highestI = points.length - 1;
   if (highestI < 0) return null;
-  if (highestI === 0) return 0;
+  if (highestI === 0) return points[0].idx;
   
   var lowestI = 0;
   
   // if values of x axis are in descending order, reverse searching borders
-  if (gs.getValue(0, 0) > gs.getValue(highestI, 0)) {
+  if (points[0].xval > points[highestI].xval) {
     lowestI = highestI;
     highestI = 0;
   }
@@ -191,8 +193,8 @@ function closestIdx(gs, x) {
     var middleI = Math.round( (lowestI + highestI) * 0.5 );
     if (middleI === lowestI || middleI === highestI) break;
     
-    var middleX = gs.getValue(middleI, 0);
-    if (middleX === x) return middleI;
+    var middleX = points[middleI].xval;
+    if (middleX === x) return points[middleI].idx;
     
     if (x < middleX) {
       highestI = middleI;
@@ -201,11 +203,9 @@ function closestIdx(gs, x) {
     }
   }
   
-  var lowestValue = gs.getValue(lowestI, 0);
-  var highestValue = gs.getValue(highestI, 0);
-  var closestI = x - lowestValue < highestValue - x ? lowestI : highestI;
+  var closestI = x - points[lowestI].xval < points[highestI].xval - x ? lowestI : highestI;
   
-  return closestI;
+  return points[closestI].idx;
 }
 
 function attachZoomHandlers(gs, syncOpts, prevCallbacks) {

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -208,6 +208,21 @@ function closestIdx(gs, x) {
   return points[closestI].idx;
 }
 
+function isInsideDateWindow(gs, idx) {
+  if (idx === null) return false;
+  var xAxisRange = gs.xAxisRange();
+  var min, max;
+  if (xAxisRange[0] <= xAxisRange[1]) {
+    min = xAxisRange[0];
+    max = xAxisRange[1];
+  } else {
+    min = xAxisRange[1];
+    max = xAxisRange[0];
+  }
+  var xval = gs.getValue(idx, 0);
+  return xval >= min && xval <= max;
+}
+
 function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
   var block = false;
   for (var i = 0; i < gs.length; i++) {
@@ -284,8 +299,10 @@ function attachSelectionHandlers(gs, syncOpts, prevCallbacks) {
             if (gs[i].numRows() === me.numRows()) idx = gs[i].getRowForX(x);
             if (idx === null) idx = closestIdx(gs[i], x);
           }
-          if (idx !== null) {
+          if (isInsideDateWindow(gs[i], idx)) {
             gs[i].setSelection(idx, seriesName, undefined, true);
+          } else {
+            gs[i].clearSelection();
           }
         }
         block = false;

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -205,9 +205,18 @@ function closestIdx(gs, x) {
   
   var closestI;
   
-  // if graph in stepPlot mode, return left point, otherwise closest x value point
-  if (gs.getOption('stepPlot') === true) closestI = lowestI < highestI ? lowestI : highestI;
-  else closestI = x - points[lowestI].xval < points[highestI].xval - x ? lowestI : highestI;
+  // if graph in stepPlot mode, check right point for match
+  // if right point matched, return it, otherwise return left point
+  // if graph is not in stepPlot mode, return closest by x value point
+  if (gs.getOption('stepPlot') === true) {
+    if (lowestI < highestI) {
+      closestI = points[highestI].xval === x ? highestI : lowestI;
+    } else {
+      closestI = points[lowestI].xval === x ? lowestI : highestI;
+    }
+  } else {
+    closestI = x - points[lowestI].xval < points[highestI].xval - x ? lowestI : highestI;
+  }
   
   return points[closestI].idx;
 }


### PR DESCRIPTION
Adds `selectClosest` option to synchronizer plugin so it selects values closest to desired. Defaults to false.
It can be helpful when graphs have not identical x axes data. (For example, when a graph has only one of each n values of another, or the values are different, but are close visually)

As the added search method `closestIdx()` is a bit slower (about 3 time slower than `getRowForX()`), I have added some optimization logic:
If the option is turned on, it checks graphs rows lengths first. If they are equal, it assumes that axes have identical values and thus tries to use `getRowForX()`. Otherwise, or if the value was not found, it uses new `closestIdx()` search function (uses binary search algorithm).