### PR TITLE
Synchronizer plugin vertical zoom ignorance fix

### DIFF
--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -193,17 +193,11 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
 
         block = true;
         
-        var opts = {};
-        if (me.isZoomed('x'))
-          opts.dateWindow = me.xAxisRange();
-        else
-          opts.dateWindow = null;
-        if (syncOpts.range) {
-          if (me.isZoomed('y'))
-            opts.valueRange = me.yAxisRange();
-          else
-            opts.valueRange = null;
-        }
+        var opts = {
+          dateWindow: me.xAxisRange()
+        };
+        if (syncOpts.range)
+          opts.valueRange = me.yAxisRange();
 
         for (let j = 0; j < gs.length; j++) {
           if (gs[j] == me) {

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -194,11 +194,17 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
         block = true;
         
         var opts = {};
-        if (me.isZoomed('x')) opts.dateWindow = me.xAxisRange();
-        else opts.dateWindow = null;
+        if (me.isZoomed('x')) {
+          opts.dateWindow = me.xAxisRange();
+        } else {
+          opts.dateWindow = null;
+        }
         if (syncOpts.range) {
-            if (me.isZoomed('y')) opts.valueRange = me.yAxisRange();
-            else opts.valueRange = null;
+          if (me.isZoomed('y')) {
+            opts.valueRange = me.yAxisRange();
+          } else {
+            opts.valueRange = null;
+          }
         }
 
         for (let j = 0; j < gs.length; j++) {
@@ -212,11 +218,17 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
           // If X-zoom differs, update
           var update = !arraysAreEqual(opts.dateWindow, gs[j].getOption('dateWindow'));
           // If Y-zoom differs and syncing, update
-          if (!update && syncOpts.range && !arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange'))) update = true;
+          if (!update && syncOpts.range && !arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange'))) {
+            update = true;
+          }
           // If about to update, but not syncing Y-zoom, pass current value
-          if (update && !syncOpts.range) opts.valueRange = gs[j].yAxisRange();
-          
-          if (update) gs[j].updateOptions(opts);
+          if (update && !syncOpts.range) {
+            opts.valueRange = gs[j].yAxisRange();
+          }
+
+          if (update) {
+            gs[j].updateOptions(opts);
+          }
         }
         block = false;
       }

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -194,17 +194,15 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
         block = true;
         
         var opts = {};
-        if (me.isZoomed('x')) {
+        if (me.isZoomed('x'))
           opts.dateWindow = me.xAxisRange();
-        } else {
+        else
           opts.dateWindow = null;
-        }
         if (syncOpts.range) {
-          if (me.isZoomed('y')) {
+          if (me.isZoomed('y'))
             opts.valueRange = me.yAxisRange();
-          } else {
+          else
             opts.valueRange = null;
-          }
         }
 
         for (let j = 0; j < gs.length; j++) {
@@ -218,17 +216,14 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
           // If X-zoom differs, update
           var update = !arraysAreEqual(opts.dateWindow, gs[j].getOption('dateWindow'));
           // If Y-zoom differs and syncing, update
-          if (!update && syncOpts.range && !arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange'))) {
+          if (!update && syncOpts.range && !arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange')))
             update = true;
-          }
           // If about to update, but not syncing Y-zoom, pass current value
-          if (update && !syncOpts.range) {
+          if (update && !syncOpts.range)
             opts.valueRange = gs[j].yAxisRange();
-          }
 
-          if (update) {
+          if (update)
             gs[j].updateOptions(opts);
-          }
         }
         block = false;
       }

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -195,6 +195,8 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
         var opts = {
           dateWindow: me.xAxisRange()
         };
+        if (!me.isZoomed('x'))
+          opts.dateWindow = null;
         if (syncOpts.range)
           opts.valueRange = me.yAxisRange();
 
@@ -207,7 +209,7 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
           }
 
           // Only redraw if there are new options
-          if (arraysAreEqual(opts.dateWindow, gs[j].xAxisRange()) &&
+          if (arraysAreEqual(opts.dateWindow, gs[j].getOption('dateWindow')) &&
               (!syncOpts.range ||
                arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange')))) {
             continue;

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -192,13 +192,10 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
         }
 
         block = true;
-        var opts = {
-          dateWindow: me.xAxisRange()
-        };
-        if (!me.isZoomed('x'))
-          opts.dateWindow = null;
-        if (syncOpts.range)
-          opts.valueRange = me.yAxisRange();
+        
+        var opts = {};
+        opts.dateWindow = me.isZoomed('x') ? me.xAxisRange() : null;
+        if (syncOpts.range) opts.valueRange = me.isZoomed('y') ? me.yAxisRange() : null;
 
         for (let j = 0; j < gs.length; j++) {
           if (gs[j] == me) {
@@ -208,14 +205,14 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
             continue;
           }
 
-          // Only redraw if there are new options
-          if (arraysAreEqual(opts.dateWindow, gs[j].getOption('dateWindow')) &&
-              (!syncOpts.range ||
-               arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange')))) {
-            continue;
-          }
+            // If X-zoom differs, update
+            var update = !arraysAreEqual(opts.dateWindow, gs[j].getOption('dateWindow'))
+            // If Y-zoom differs and syncing, update
+            if (!update && syncOpts.range && !arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange'))) update = true;
+            // If about to update, but not syncing Y-zoom, pass current value
+            if (update && !syncOpts.range) opts.valueRange = gs[j].yAxisRange()
 
-          gs[j].updateOptions(opts);
+            if (update) gs[j].updateOptions(opts)
         }
         block = false;
       }

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -195,8 +195,6 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
         var opts = {
           dateWindow: me.xAxisRange()
         };
-        if (!me.isZoomed('x'))
-          opts.dateWindow = null;
         if (syncOpts.range)
           opts.valueRange = me.yAxisRange();
 
@@ -209,7 +207,7 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
           }
 
           // Only redraw if there are new options
-          if (arraysAreEqual(opts.dateWindow, gs[j].getOption('dateWindow')) &&
+          if (arraysAreEqual(opts.dateWindow, gs[j].xAxisRange()) &&
               (!syncOpts.range ||
                arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange')))) {
             continue;

--- a/src/extras/synchronizer.js
+++ b/src/extras/synchronizer.js
@@ -194,8 +194,12 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
         block = true;
         
         var opts = {};
-        opts.dateWindow = me.isZoomed('x') ? me.xAxisRange() : null;
-        if (syncOpts.range) opts.valueRange = me.isZoomed('y') ? me.yAxisRange() : null;
+        if (me.isZoomed('x')) opts.dateWindow = me.xAxisRange();
+        else opts.dateWindow = null;
+        if (syncOpts.range) {
+            if (me.isZoomed('y')) opts.valueRange = me.yAxisRange();
+            else opts.valueRange = null;
+        }
 
         for (let j = 0; j < gs.length; j++) {
           if (gs[j] == me) {
@@ -205,14 +209,14 @@ function attachZoomHandlers(gs, syncOpts, prevCallbacks) {
             continue;
           }
 
-            // If X-zoom differs, update
-            var update = !arraysAreEqual(opts.dateWindow, gs[j].getOption('dateWindow'))
-            // If Y-zoom differs and syncing, update
-            if (!update && syncOpts.range && !arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange'))) update = true;
-            // If about to update, but not syncing Y-zoom, pass current value
-            if (update && !syncOpts.range) opts.valueRange = gs[j].yAxisRange()
-
-            if (update) gs[j].updateOptions(opts)
+          // If X-zoom differs, update
+          var update = !arraysAreEqual(opts.dateWindow, gs[j].getOption('dateWindow'));
+          // If Y-zoom differs and syncing, update
+          if (!update && syncOpts.range && !arraysAreEqual(opts.valueRange, gs[j].getOption('valueRange'))) update = true;
+          // If about to update, but not syncing Y-zoom, pass current value
+          if (update && !syncOpts.range) opts.valueRange = gs[j].yAxisRange();
+          
+          if (update) gs[j].updateOptions(opts);
         }
         block = false;
       }


### PR DESCRIPTION
Having several graphs synced, I wanted their vertical zooming to be independent. Setting synchronizer `range` option to `false` currently does that, but only partially.

1. If you are not x-zoomed in, then it works when you y-zoom one of the graphs for the first time, but if you y-zoom another graph after that, it resets first one.
2. If you are x-zoomed in, then it partially preserves vertical zooms, but still reset graphs depending on their position in the syncing graphs array.

For the first case I found that the source is `arraysAreEqual(a, b)` returning `false` while comparing x-axis arrays when both arrays are `null`. Since in dygraph null x axis (dateWindow) array means 'fully zoomed out', this should be treaten as equal zooming ranges. Adding a check like this
```
function arraysAreEqual(a, b) {
  if (a === null && b === null) return true
  ...
}
```
solved first case, but... [it would take too long to explain, deleted] it was still very buggy.

In short, I figured out that other arrays should be used when comparing. Using `xAxisRange()` instead of `getOption('dateWindow')` for that gives consistent expected result, so here's the fix.

The only issue I found after, is that it still resets graphs sometimes after x-zooming in and out due to precision error. For example, in my case, graphs had the ranges for x-axis equal to `[1.5e-7, 0.00015]` and after x-zooming in and out for one of them it changes to `[1.5e-7, 0.00015000000000000001]`. Thus, comparing the ranges after that, it founds them are different, resetting graphs as a result. It would be more right to fix this somewhere inside zooming handler in dygraph core.