### PR TITLE
Crosshair plugin - initial canvas size fix

### DIFF
--- a/src/extras/crosshair.js
+++ b/src/extras/crosshair.js
@@ -28,18 +28,18 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
 
   var crosshair = function crosshair(opt_options) {
     this.canvas_ = document.createElement("canvas");
-    this.updateCanvasSize(0, 0)
     opt_options = opt_options || {};
     this.direction_ = opt_options.direction || null;
     this.strokeStyle_ = opt_options.strokeStyle || "rgba(0, 0, 0, 0.3)";
   };
 
   crosshair.prototype.updateCanvasSize = function updateCanvasSize(width, height) {
-    this.canvas_.width = width
-    this.canvas_.height = height
-    this.canvas_.style.width = width.toString(10) + 'px'    // for IE
-    this.canvas_.style.height = height.toString(10) + 'px'  // for IE
-  }
+    if (width === this.canvas_.width && height === this.canvas_.height) return;
+    this.canvas_.width = width;
+    this.canvas_.height = height;
+    this.canvas_.style.width = width + 'px';    // for IE
+    this.canvas_.style.height = height + 'px';  // for IE
+  };
 
   crosshair.prototype.toString = function toString() {
     return "Crosshair Plugin";
@@ -50,6 +50,7 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
    * @return {object.<string, function(ev)>} Mapping of event names to callbacks.
    */
   crosshair.prototype.activate = function activate(g) {
+    this.updateCanvasSize(g.width_, g.height_);
     g.graphDiv.appendChild(this.canvas_);
 
     return {
@@ -65,7 +66,7 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
 
     var width = e.dygraph.width_;
     var height = e.dygraph.height_;
-    this.updateCanvasSize(width, height)
+    this.updateCanvasSize(width, height);
 
     var ctx = this.canvas_.getContext("2d");
     ctx.clearRect(0, 0, width, height);

--- a/src/extras/crosshair.js
+++ b/src/extras/crosshair.js
@@ -28,10 +28,18 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
 
   var crosshair = function crosshair(opt_options) {
     this.canvas_ = document.createElement("canvas");
+    this.updateCanvasSize(0, 0)
     opt_options = opt_options || {};
     this.direction_ = opt_options.direction || null;
     this.strokeStyle_ = opt_options.strokeStyle || "rgba(0, 0, 0, 0.3)";
   };
+
+  crosshair.prototype.updateCanvasSize = function updateCanvasSize(width, height) {
+    this.canvas_.width = width
+    this.canvas_.height = height
+    this.canvas_.style.width = width.toString(10) + 'px'    // for IE
+    this.canvas_.style.height = height.toString(10) + 'px'  // for IE
+  }
 
   crosshair.prototype.toString = function toString() {
     return "Crosshair Plugin";
@@ -57,10 +65,7 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
 
     var width = e.dygraph.width_;
     var height = e.dygraph.height_;
-    this.canvas_.width = width;
-    this.canvas_.height = height;
-    this.canvas_.style.width = width + "px";    // for IE
-    this.canvas_.style.height = height + "px";  // for IE
+    this.updateCanvasSize(width, height)
 
     var ctx = this.canvas_.getContext("2d");
     ctx.clearRect(0, 0, width, height);


### PR DESCRIPTION
Crosshair plugin creates canvas to draw its lines, but if the graph is small enough, this canvas can block interaction with other elements until you hover over a graph giving it a chance to resize. Canvas initializes with 300x150 which is default [Canvas element - Wikipedia](https://en.wikipedia.org/wiki/Canvas_element#:~:text=By%20default%2C%20both%20the%20canvas,and%20150%20screen%20pixels%20high.)

In the example below it overlaps the '+' button preventing clicking it

![dgCanvas](https://user-images.githubusercontent.com/58081918/236663701-27cefe36-07a9-4f0d-a08c-944657b27c83.gif)

To fix it I have set the size to [0,0] in plugin constructor.