### PR TITLE
Crosshair plugin - out of graph bounds selection filter

### DIFF
--- a/src/extras/crosshair.js
+++ b/src/extras/crosshair.js
@@ -67,8 +67,8 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
     ctx.strokeStyle = this.strokeStyle_;
     ctx.beginPath();
     
-    var point = e.dygraph.selPoints_[0];
-    if (point.x >= 0 && point.x <= 1) {
+    var p_x = e.dygraph.selPoints_[0];
+    if (p_x.x >= 0 && p_x.x <= 1) {
       var canvasx = Math.floor(e.dygraph.selPoints_[0].canvasx) + 0.5; // crisper rendering
   
       if (this.direction_ === "vertical" || this.direction_ === "both") {
@@ -79,7 +79,9 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
 
     if (this.direction_ === "horizontal" || this.direction_ === "both") {
       for (var i = 0; i < e.dygraph.selPoints_.length; i++) {
-        var canvasy = Math.floor(e.dygraph.selPoints_[i].canvasy) + 0.5; // crisper rendering
+        var p_y = e.dygraph.selPoints_[i];
+        if (p_y.y < 0 || p_y > 1) continue;
+        var canvasy = Math.floor(p_y.canvasy) + 0.5; // crisper rendering
         ctx.moveTo(0, canvasy);
         ctx.lineTo(width, canvasy);
       }

--- a/src/extras/crosshair.js
+++ b/src/extras/crosshair.js
@@ -69,7 +69,7 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
     
     var p_x = e.dygraph.selPoints_[0];
     if (p_x.x >= 0 && p_x.x <= 1) {
-      var canvasx = Math.floor(e.dygraph.selPoints_[0].canvasx) + 0.5; // crisper rendering
+      var canvasx = Math.floor(p_x.canvasx) + 0.5; // crisper rendering
   
       if (this.direction_ === "vertical" || this.direction_ === "both") {
         ctx.moveTo(canvasx, 0);

--- a/src/extras/crosshair.js
+++ b/src/extras/crosshair.js
@@ -66,12 +66,15 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
     ctx.clearRect(0, 0, width, height);
     ctx.strokeStyle = this.strokeStyle_;
     ctx.beginPath();
-
-    var canvasx = Math.floor(e.dygraph.selPoints_[0].canvasx) + 0.5; // crisper rendering
-
-    if (this.direction_ === "vertical" || this.direction_ === "both") {
-      ctx.moveTo(canvasx, 0);
-      ctx.lineTo(canvasx, height);
+    
+    var point = e.dygraph.selPoints_[0];
+    if (point.x >= 0 && point.x <= 1) {
+      var canvasx = Math.floor(e.dygraph.selPoints_[0].canvasx) + 0.5; // crisper rendering
+  
+      if (this.direction_ === "vertical" || this.direction_ === "both") {
+        ctx.moveTo(canvasx, 0);
+        ctx.lineTo(canvasx, height);
+      }
     }
 
     if (this.direction_ === "horizontal" || this.direction_ === "both") {


### PR DESCRIPTION
When the graph is zoomed in, crosshair can select points out of view area, drawing lines off graph.
Below is example where the area on the left is caused by `axisLabelWidth`, so it is inside crosshair drawing canvas.

![chBounds](https://github.com/danvk/dygraphs/assets/58081918/e8a824ad-9362-49b4-a9b9-8e0b8dee22d7)

The same happens on the right side when using `rightGap`. Filtered by checking `selectedPoint.x` to be in [0,1]