### PR TITLE
Crosshair plugin - last point selection edge case visual fix

### DIFF
--- a/src/extras/crosshair.js
+++ b/src/extras/crosshair.js
@@ -68,6 +68,7 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
     ctx.beginPath();
 
     var canvasx = Math.floor(e.dygraph.selPoints_[0].canvasx) + 0.5; // crisper rendering
+    if (canvasx > width) canvasx = width - 0.5;
 
     if (this.direction_ === "vertical" || this.direction_ === "both") {
       ctx.moveTo(canvasx, 0);
@@ -77,6 +78,7 @@ Dygraph.Plugins.Crosshair = (function _extras_crosshair_closure() {
     if (this.direction_ === "horizontal" || this.direction_ === "both") {
       for (var i = 0; i < e.dygraph.selPoints_.length; i++) {
         var canvasy = Math.floor(e.dygraph.selPoints_[i].canvasy) + 0.5; // crisper rendering
+        if (canvasy > height) canvasy = height - 0.5;
         ctx.moveTo(0, canvasy);
         ctx.lineTo(width, canvasy);
       }


### PR DESCRIPTION
Crosshair draws its lines at position +0.5 of pixel size to get crisp lines, but if the selected point is at the end of graph, this results in drawing the line off-graph. To avoid this and get the line visible, the `rightGap` option has to be set 1+.
Below is two graphs, which has rightGap = 1 and 0 respectively

![crhLastpoint](https://github.com/danvk/dygraphs/assets/58081918/f06c9b4b-03e0-4de6-9051-757e12c1c58d)

I thought about several solutions, but it seems like just fixing the edge case fits best