### PR TITLE
Fix selection fade frame progression

### DIFF
--- a/auto_tests/tests/highlight_series_background.js
+++ b/auto_tests/tests/highlight_series_background.js
@@ -123,6 +123,35 @@ describe("highlight-series-background", function() {
     }, 500);
   });
 
+  it('testSelectionAnimationWithReducedFPS', function() {
+    var graph = setupGraph(0.7,'rgb(255,0,0)');
+    var frameCallback, middleFrameNum, lastFrameNum, cleanupCallback;
+    utils.repeatAndCleanup = function (repeatFn, maxFrames, framePeriodInMillis, cleanupFn) {
+      frameCallback = repeatFn;
+      cleanupCallback = cleanupFn;
+      middleFrameNum = Math.round(maxFrames / 2) - 1;
+      lastFrameNum = maxFrames - 1;
+      frameCallback(0);
+    }
+    var expectedFinalAlpha = 76;
+
+    assert.deepEqual(Util.samplePixel(graph.canvas_, 100, 100), [0,0,0,0]);
+
+    graph.setSelection(0, 'y', true);
+
+    frameCallback(middleFrameNum);
+    var colorAfterMiddleFrame = Util.samplePixel(graph.canvas_, 100, 100);
+
+    frameCallback(lastFrameNum);
+    cleanupCallback();
+    var colorAtTheEnd = Util.samplePixel(graph.canvas_, 100, 100);
+
+    assert.deepEqual(
+      [colorAfterMiddleFrame, colorAtTheEnd],
+      [[255,0,0, expectedFinalAlpha / 2], [255,0,0, expectedFinalAlpha]],
+    );
+  });
+
   it('testGetSelectionZeroCanvasY', function () {
     var graph = document.getElementById("graph");
     var calls = []

--- a/src/dygraph.js
+++ b/src/dygraph.js
@@ -1715,27 +1715,20 @@ Dygraph.prototype.animateSelection_ = function(direction) {
 
   var thisId = ++this.animateId;
   var that = this;
-  var cleanupIfClearing = function() {
-    // if we haven't reached fadeLevel 0 in the max frame time,
-    // ensure that the clear happens and just go to 0
-    if (that.fadeLevel !== 0 && direction < 0) {
-      that.fadeLevel = 0;
-      that.clearSelection();
-    }
-  };
+
   utils.repeatAndCleanup(
-    function(n) {
+    function(step) {
       // ignore simultaneous animations
       if (that.animateId != thisId) return;
 
-      that.fadeLevel += direction;
+      that.fadeLevel = start + (step + 1) * direction;
       if (that.fadeLevel === 0) {
         that.clearSelection();
       } else {
         that.updateSelection_(that.fadeLevel / totalSteps);
       }
     },
-    steps, millis, cleanupIfClearing);
+    steps, millis, function() {});
 };
 
 /**


### PR DESCRIPTION
#### Problem

Selection overlay animation progresses the alpha value by 0.1 in each frame, regardless of the time between the frames. If CPU is busy and can't render enough frames, the animation can lag and finish in wrong state (with lower overlay alpha than expected). It's been mitigated for clearSelection case, which will be eventually called regardless of number of rendered frames, but it's handled as special case, which is rather messy.

#### Change explanation

The callback sent to `repeatAndCleanup()` in `animateSelection_` so far ignored the frame number sent by `repeatAndCleanup()`.

The code was assuming that it will be called `steps` time, which is not true if CPU is saturated and there are longer intervals between frames then expected - frames in the middle will be dropped. `repeatAndCleanup()` guarantees that it will call the callback with last step, but without checking the step number it's impossible to leverage that.

https://github.com/danvk/dygraphs/pull/534 patched the code to ensure that at least `clearSelection` is called at the end, but it seems like unnecessary complication, and doesn't fix the fade progression if the frames are delayed or irregular.

With current `fadeLevel` computed from the actual step, the cleanup function is no longer necessary - `repeatAndCleanup()` will always call the fallback with last step, and with fixed `fadeLevel` computation it will trigger `clearSelection` as necessary.

#### Why it's useful:

This simplifies the code and improves the behavior - it guarantees that both fade-in and fade-out will finish with the right values, and that the fade value change will be proportional regardless of effective FPS.