### PR TITLE
EventListeners violation - more selective options

### DIFF
--- a/src/dygraph-utils.js
+++ b/src/dygraph-utils.js
@@ -101,11 +101,10 @@ export var getContext = function(canvas) {
  * EventListener options
  */
 function _eventListenerOptions(type) {
-  const options = { capture: false };
   if (type === 'touchstart' || type === 'touchmove') {
-      options.passive = true;
+      return { capture: false, passive: true };
   }
-  return options;
+  return false;
 }
 
 /**


### PR DESCRIPTION
@mirabilos I'm wondering, if PhantomJS supports `touchstart` and `touchmove` at all, so, if it discards them, but wants boolean for everything else, maybe we just pass options object only for touch events, and `false` fot others, like it was before
Can you check this?